### PR TITLE
Bump up content-atom version

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -9,7 +9,7 @@ name := "atom-manager-play"
 libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
-  "org.typelevel"          %% "cats-core"             % "0.6.0",
+  "org.typelevel"          %% "cats-core"             % "0.7.0",
   "org.scalatestplus.play" %% "scalatestplus-play"    % "1.5.0"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
   "org.mockito"            %  "mockito-core"          % mockitoVersion % "test"

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/AtomDynamoFormats.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/AtomDynamoFormats.scala
@@ -31,11 +31,10 @@ trait AtomDynamoFormats[A] {
     new DynamoFormat[AtomData] {
       def write(atomData: AtomData): AttributeValue = {
         val pf = fromAtomData andThen { case data: A => arg0.write(data) }
-        pf.applyOrElse(atomData, fallback _)
+        pf.applyOrElse(atomData, fallback)
       }
 
-      def read(attr: AttributeValue) = arg0.read(attr) map (toAtomData _)
-
+      def read(attr: AttributeValue) = arg0.read(attr) map toAtomData
     }
 }
 

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -50,7 +50,7 @@ abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
       _ => ReadError
     }
 
-  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(tableName).rightMap(_.iterator)
+  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(tableName).map(_.iterator)
 }
 
 abstract class PreviewDynamoDataStore[D : ClassTag : DynamoFormat]
@@ -62,7 +62,7 @@ abstract class PreviewDynamoDataStore[D : ClassTag : DynamoFormat]
     val validationCheck = NestedKeyIs(
       List('contentChangeDetails, 'revision), LT, newAtom.contentChangeDetails.revision
     )
-    val res = (Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom)))
+    val res = Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom))
     res.map(_ => ())
       .leftMap(_ => VersionConflictError(newAtom.contentChangeDetails.revision))
   }
@@ -75,5 +75,5 @@ abstract class PublishedDynamoDataStore[D : ClassTag : DynamoFormat]
   with PublishedDataStore {
 
   def updateAtom(newAtom: Atom) =
-    succeed((Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom))))
+    succeed(Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom)))
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/TestData.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/TestData.scala
@@ -33,7 +33,9 @@ object TestData {
           plutoProjectId = None,
           duration = None,
           source = None,
-          posterUrl = None
+          posterUrl = None,
+          description = None,
+          metadata = None
         )
       ),
       contentChangeDetails = ContentChangeDetails(revision = 1)
@@ -64,17 +66,19 @@ object TestData {
           plutoProjectId = None,
           duration = None,
           source = None,
-          posterUrl = None
+          posterUrl = None,
+          description = None,
+          metadata = None
         )
       ),
       contentChangeDetails = ContentChangeDetails(revision = 1)
     )
   )
 
-  def testAtomEvents = testAtoms.map(testAtomEvent _)
+  def testAtomEvents = testAtoms.map(testAtomEvent)
 
   val testAtom = testAtoms.head
 
   def testAtomEvent(atom: Atom = testAtom) =
-    ContentAtomEvent(testAtom, EventType.Update, (new Date()).getTime())
+    ContentAtomEvent(testAtom, EventType.Update, new Date().getTime)
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/AtomDynamoFormatsSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/AtomDynamoFormatsSpec.scala
@@ -18,7 +18,7 @@ import ScanamoUtil._
 class AtomDynamoFormatsSpec extends FunSpec with Matchers {
   //implicit val shortFmt = DynamoFormat.xmap[Short, Int](i => Xor.Right(i.toShort))(_.toInt)
 
-  val testAtomData: AtomData = AtomData.Media(MediaAtom(Nil, Some(1L), "Test media atom", Category.Feature))
+  val testAtomData: AtomData = AtomData.Media(MediaAtom(Nil, Some(1L), "Test media atom", Category.Feature, Some("Description"), None))
 
   describe("atomdata dynamo format") {
     it("should convert test atom") {

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/AtomDynamoFormatsSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/AtomDynamoFormatsSpec.scala
@@ -18,7 +18,22 @@ import ScanamoUtil._
 class AtomDynamoFormatsSpec extends FunSpec with Matchers {
   //implicit val shortFmt = DynamoFormat.xmap[Short, Int](i => Xor.Right(i.toShort))(_.toInt)
 
-  val testAtomData: AtomData = AtomData.Media(MediaAtom(Nil, Some(1L), "Test media atom", Category.Feature, Some("Description"), None))
+  val testAtomData: AtomData = AtomData.Media(MediaAtom(
+    assets = Nil,
+    activeVersion = Some(1L),
+    title = "Test media atom",
+    category = Category.Feature,
+    plutoProjectId = Some("PlutoId"),
+    duration = None,
+    source = Some("YouTube"),
+    posterUrl = None,
+    description = Some("Description"),
+    metadata = Some(Metadata(
+      tags = Some(Seq("tag1", "tag2")),
+      categoryId = Some("categoryId"),
+      license = None,
+      commentsEnabled = Some(true),
+      channelId = None))))
 
   describe("atomdata dynamo format") {
     it("should convert test atom") {

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -10,6 +10,6 @@ object BuildVars {
 
   lazy val scanamoDeps = Seq(
     "com.gu"                     %% "scanamo"          % "0.7.0",
-    "com.gu"                     %% "scanamo-scrooge"  % "0.1.2"
+    "com.gu"                     %% "scanamo-scrooge"  % "0.1.3"
   )
 }

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.10.69"
-  lazy val contentAtomVersion = "2.4.0"
+  lazy val contentAtomVersion = "2.4.6"
   lazy val scroogeVersion     = "4.2.0"
   lazy val akkaVersion        = "2.4.8"
   lazy val playVersion        = "2.5.3"

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object BuildVars {
-  lazy val awsVersion         = "1.10.69"
+  lazy val awsVersion         = "1.11.48"
   lazy val contentAtomVersion = "2.4.6"
   lazy val scroogeVersion     = "4.2.0"
   lazy val akkaVersion        = "2.4.8"

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -9,7 +9,7 @@ object BuildVars {
   lazy val mockitoVersion     = "2.0.97-beta"
 
   lazy val scanamoDeps = Seq(
-    "com.gu"                     %% "scanamo"              % "0.6.0",
-    "com.gu"                     %% "scanamo-scrooge"      % "0.1.2"
+    "com.gu"                     % "scanamo_2.11"          % "0.7.0",
+    "com.gu"                     % "scanamo-scrooge_2.11"  % "0.1.2"
   )
 }

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -9,7 +9,7 @@ object BuildVars {
   lazy val mockitoVersion     = "2.0.97-beta"
 
   lazy val scanamoDeps = Seq(
-    "com.gu"                     % "scanamo_2.11"          % "0.7.0",
-    "com.gu"                     % "scanamo-scrooge_2.11"  % "0.1.2"
+    "com.gu"                     %% "scanamo"          % "0.7.0",
+    "com.gu"                     %% "scanamo-scrooge"  % "0.1.2"
   )
 }


### PR DESCRIPTION
New fields have been added to the `content-atom` thrift model: https://github.com/guardian/content-atom/pull/39