### PR TITLE
Bump content atom version.

### DIFF
--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/ScanamoUtil.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/ScanamoUtil.scala
@@ -25,8 +25,6 @@ object ScanamoUtil {
   implicit def seqFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Seq[T]] =
     xmap[Seq[T], List[T]](l => Xor.right(l.toSeq))(_.toList)
 
-  implicit val flagsFormat = xmap[Flags, Option[Boolean]](o => Xor.right(Flags.apply(o)))(f => Flags.unapply(f).get)
-
   // joins keys with a document separator to dig into MultipleValue keys
   case class NestedKeyIs[V : DynamoFormat](keys: List[Symbol], operator: DynamoOperator, v: V)
 

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.48"
-  lazy val contentAtomVersion = "2.4.6"
+  lazy val contentAtomVersion = "2.4.16"
   lazy val scroogeVersion     = "4.2.0"
   lazy val akkaVersion        = "2.4.8"
   lazy val playVersion        = "2.5.3"


### PR DESCRIPTION
Using this library with media-atom-maker was causing issues as this uses an old version of the content atom. Bumped the version and removed unneeded implicit. 