### PR TITLE
Bump scanamo and scrooge

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -9,7 +9,6 @@ name := "atom-manager-play"
 libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
-  "org.typelevel"          %% "cats-core"             % "0.7.0",
   "org.scalatestplus.play" %% "scalatestplus-play"    % "1.5.0"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
   "org.mockito"            %  "mockito-core"          % mockitoVersion % "test"

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
@@ -1,6 +1,6 @@
 package com.gu.atom.play
 
-import cats.data.Xor
+import cats.syntax.either._
 import com.gu.atom.data._
 import com.gu.atom.publish._
 import com.gu.contentatom.thrift._
@@ -44,8 +44,8 @@ trait AtomAPIActions extends Controller {
     livePublisher.publishAtomEvent(event) match {
       case Success(_) =>
         publishedDataStore.updateAtom(updatedAtom) match {
-          case Xor.Right(_) => NoContent
-          case Xor.Left(err) => InternalServerError(
+          case Right(_) => NoContent
+          case Left(err) => InternalServerError(
             jsonError(s"could not update after publish: ${err.toString}")
           )
         }

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -5,7 +5,6 @@ import com.gu.contentatom.thrift._
 import org.mockito.Mockito._
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import cats.syntax.either._
 import com.gu.atom.play._
 import play.api.mvc.Controller
 import play.api.test.Helpers._

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -5,7 +5,7 @@ import com.gu.contentatom.thrift._
 import org.mockito.Mockito._
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import cats.data.Xor
+import cats.syntax.either._
 import com.gu.atom.play._
 import play.api.mvc.Controller
 import play.api.test.Helpers._
@@ -19,7 +19,7 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
 
   override def initialPublishedDataStore = {
     val m = publishedDataStoreMockWithTestData
-    when(m.updateAtom(any())).thenReturn(Xor.Right(()))
+    when(m.updateAtom(any())).thenReturn(Right(()))
     m
   }
 

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -1,7 +1,6 @@
 package com.gu.atom.play.test
 
 import scala.util.{Failure, Success}
-import cats.data.Xor
 import com.gu.atom.TestData
 
 import scala.collection.mutable.{ Map => MMap }

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -30,5 +30,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
   "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
   "org.scalatest"              %% "scalatest"            % "2.2.6"     % "test",
-  "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test"
+  "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test",
+  "org.typelevel"              %% "cats-core"            % "0.9.0"
 ) ++  scanamoDeps

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/AtomDynamoFormats.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/AtomDynamoFormats.scala
@@ -12,7 +12,7 @@ import scala.reflect.macros.blackbox.Context
 import com.gu.scanamo.scrooge.ScroogeDynamoFormat
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 
-import cats.data.Xor
+import cats.syntax.either._
 
 import ScroogeDynamoFormat._
 import DynamoFormat._

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -1,6 +1,6 @@
 package com.gu.atom.data
 
-import cats.data.Xor
+import cats.syntax.either._
 import com.gu.contentatom.thrift.Atom
 
 import com.typesafe.scalalogging.LazyLogging
@@ -31,10 +31,10 @@ trait DataStore extends DataStoreResult {
 }
 
 trait DataStoreResult {
-  type DataStoreResult[R] = Xor[DataStoreError, R]
+  type DataStoreResult[R] = Either[DataStoreError, R]
 
-  def fail(error: DataStoreError): DataStoreResult[Nothing] = Xor.left(error)
-  def succeed[R](result: => R): DataStoreResult[R] = Xor.right(result)
+  def fail(error: DataStoreError): DataStoreResult[Nothing] = Left(error)
+  def succeed[R](result: => R): DataStoreResult[R] = Right(result)
 }
 
 object DataStoreResult extends DataStoreResult

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -5,8 +5,10 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.gu.contentatom.thrift.{ Atom, AtomData, Flags }
 import com.gu.scanamo.{ Scanamo, DynamoFormat, Table }
 import com.gu.scanamo.query._
-import cats.data.Xor
-import cats.implicits._
+import cats.instances.either._
+import cats.instances.list._
+import cats.syntax.either._
+import cats.syntax.traverse._
 import scala.reflect.ClassTag
 import com.twitter.scrooge.ThriftStruct
 
@@ -34,7 +36,7 @@ abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
   // this should probably return an Either so we can report an error,
   // e.g. if the atom exists, but it can't be deseralised
   def getAtom(id: String): Option[Atom] = get(UniqueKey(KeyEquals('id, id))) match {
-    case Some(Xor.Right(atom)) => Some(atom)
+    case Some(Right(atom)) => Some(atom)
     case _ => None
   }
 

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -1,6 +1,6 @@
 package data
 
-import cats.data.Xor
+import cats.syntax.either._
 import com.gu.contentatom.thrift.Atom
 
 import com.gu.atom.data._
@@ -37,7 +37,7 @@ class MemoryStore extends DataStore {
     }
   }
 
-  def listAtoms = Xor.right(dataStore.values.iterator)
+  def listAtoms = Right(dataStore.values.iterator)
 }
 
 class PreviewMemoryStore(initial: Map[String, Atom]) extends MemoryStore(initial) with PreviewDataStore

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/ScanamoUtil.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/ScanamoUtil.scala
@@ -9,7 +9,7 @@ import DynamoFormat.xmap
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.contentatom.thrift.Flags
 
-import cats.data.Xor
+import cats.syntax.either._
 
 /*
  * We are using `scanamo` and `scanamo-scrooge` in this library to
@@ -23,7 +23,7 @@ import cats.data.Xor
 object ScanamoUtil {
 
   implicit def seqFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Seq[T]] =
-    xmap[Seq[T], List[T]](l => Xor.right(l.toSeq))(_.toList)
+    xmap[Seq[T], List[T]](l => Right(l.toSeq))(_.toList)
 
   // joins keys with a document separator to dig into MultipleValue keys
   case class NestedKeyIs[V : DynamoFormat](keys: List[Symbol], operator: DynamoOperator, v: V)

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/AtomDynamoFormatsSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/AtomDynamoFormatsSpec.scala
@@ -2,7 +2,7 @@ package com.gu.atom.data
 
 import org.scalatest.{ Matchers, FunSpec }
 
-import cats.data.Xor
+import cats.syntax.either._
 
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.media._
@@ -16,7 +16,6 @@ import DynamoFormat._
 import ScanamoUtil._
 
 class AtomDynamoFormatsSpec extends FunSpec with Matchers {
-  //implicit val shortFmt = DynamoFormat.xmap[Short, Int](i => Xor.Right(i.toShort))(_.toInt)
 
   val testAtomData: AtomData = AtomData.Media(MediaAtom(
     assets = Nil,
@@ -42,7 +41,7 @@ class AtomDynamoFormatsSpec extends FunSpec with Matchers {
       import MediaAtomDynamoFormats._
 
       (DynamoFormat[AtomData].read(DynamoFormat[AtomData].write(testAtomData))
-         should equal(Xor.right(testAtomData)))
+         should equal(Right(testAtomData)))
     }
   }
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -12,7 +12,7 @@ import ScanamoUtil._
 
 import com.gu.atom.util.AtomImplicitsGeneral
 
-import cats.data.Xor
+import cats.syntax.either._
 
 import com.gu.atom.TestData._
 
@@ -38,7 +38,7 @@ class DynamoDataStoreSpec
 
   describe("DynamoDataStore") {
     it("should create a new atom") { dataStores =>
-      dataStores.preview.createAtom(testAtom) should equal(Xor.Right())
+      dataStores.preview.createAtom(testAtom) should equal(Right())
     }
 
     it("should return the atom") { dataStores =>
@@ -50,7 +50,7 @@ class DynamoDataStoreSpec
         .copy(defaultHtml = "<div>updated</div>")
         .bumpRevision
 
-      dataStores.preview.updateAtom(updated) should equal(Xor.Right())
+      dataStores.preview.updateAtom(updated) should equal(Right())
       dataStores.preview.getAtom(testAtom.id).value should equal(updated)
     }
 
@@ -59,7 +59,7 @@ class DynamoDataStoreSpec
         .copy()
         .withRevision(1)
 
-      dataStores.published.updateAtom(updated) should equal(Xor.Right())
+      dataStores.published.updateAtom(updated) should equal(Right())
       dataStores.published.getAtom(testAtom.id).value should equal(updated)
     }
   }

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.48"
-  lazy val contentAtomVersion = "2.4.29"
+  lazy val contentAtomVersion = "2.4.30"
   lazy val scroogeVersion     = "4.12.0"
   lazy val akkaVersion        = "2.4.8"
   lazy val playVersion        = "2.5.3"

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -9,7 +9,7 @@ object BuildVars {
   lazy val mockitoVersion     = "2.0.97-beta"
 
   lazy val scanamoDeps = Seq(
-    "com.gu"                     %% "scanamo"          % "0.7.0",
-    "com.gu"                     %% "scanamo-scrooge"  % "0.1.3"
+    "com.gu"                     %% "scanamo"          % "0.9.0",
+    "com.gu"                     %% "scanamo-scrooge"  % "0.1.4"
   )
 }


### PR DESCRIPTION
This PR updated atom maker to use the latest version of scanamo and scanamo scrooge. This also involved moving to the latest version of cats. As a result Xor can no longer be used as it has been removed from cats 0.9.0.

While doing this work there was an issue with the test files taking a long time to compile. The compilation just hung. 2 hours was the maximum time waited and it still had not completed. This was fixed by replacing instances of `import cats.data.Xor` with `import cats.syntax.either._`