### PR TITLE
DO NOT MERGE: Don't return unit

### DIFF
--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.atom.play.test
 
-import com.gu.atom.TestData
+import com.gu.atom.TestData._
 import com.gu.contentatom.thrift._
 import org.mockito.Mockito._
 import org.mockito.ArgumentCaptor
@@ -18,7 +18,7 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
 
   override def initialPublishedDataStore = {
     val m = publishedDataStoreMockWithTestData
-    when(m.updateAtom(any())).thenReturn(Right(()))
+    when(m.updateAtom(any())).thenReturn(Right((testAtom)))
     m
   }
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "com.twitter"                %% "scrooge-core"         % scroogeVersion,
   "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
   "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
-  "org.scalatest"              %% "scalatest"            % "2.2.6"     % "test",
+  "org.scalatest"              %% "scalatest"            % "3.0.0"     % "test",
   "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test",
   "org.typelevel"              %% "cats-core"            % "0.9.0"
 ) ++  scanamoDeps

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "com.twitter"                %% "scrooge-core"         % scroogeVersion,
   "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
   "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
-  "org.scalatest"              %% "scalatest"            % "3.0.0"     % "test",
+  "org.scalatest"              %% "scalatest"            % "2.2.6" % "test",
   "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test",
   "org.typelevel"              %% "cats-core"            % "0.9.0"
 ) ++  scanamoDeps

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -21,9 +21,9 @@ trait DataStore extends DataStoreResult {
 
   def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[Atom]
 
-  def createAtom(atom: Atom): DataStoreResult[Unit]
+  def createAtom(atom: Atom): DataStoreResult[Atom]
 
-  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Unit]
+  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Atom]
 
   /* this will only allow the update if the version in atom is later
    * than the version stored in the database, otherwise it will report

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -25,13 +25,12 @@ trait DataStore extends DataStoreResult {
 
   def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Atom]
 
-  /* this will only allow the update if the version in atom is later
-   * than the version stored in the database, otherwise it will report
-   * it as a version conflict error */
-
   def listAtoms: DataStoreResult[Iterator[Atom]]
 
-  def updateAtom(newAtom: Atom): DataStoreResult[Unit]
+  /* this will only allow the update if the version in atom is later
+ * than the version stored in the database, otherwise it will report
+ * it as a version conflict error */
+  def updateAtom(newAtom: Atom): DataStoreResult[Atom]
 
   def deleteAtom(id: String): DataStoreResult[Atom]
 

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -14,6 +14,8 @@ case object ReadError extends DataStoreError("Read error")
 case class  DataError(info: String) extends DataStoreError(info)
 case class  VersionConflictError(requestVer: Long)
     extends DataStoreError(s"Update has version $requestVer, which is earlier or equal to data store version")
+case class  DynamoError(info: String) extends DataStoreError(s"Dynamo was unable to process this request. Error message ${info}")
+case class  ClientError(info: String) extends DataStoreError(s"Client was unable to get a response from a service, or if the client was unable to parse the response from a service. Error message: ${info}")
 
 trait DataStore extends DataStoreResult {
 

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -46,13 +46,15 @@ abstract class DynamoDataStore[D : ClassTag : DynamoFormat]
       case None => Left(IDNotFound)
     }
 
-  def createAtom(atom: Atom): DataStoreResult[Unit] = createAtom(DynamoCompositeKey(atom.id), atom)
+  def createAtom(atom: Atom): DataStoreResult[Atom] = createAtom(DynamoCompositeKey(atom.id), atom)
 
-  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Unit] =
+  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Atom] =
     if (get(uniqueKey(dynamoCompositeKey)).isDefined)
       fail(IDConflictError)
-    else
-      succeed(put(atom))
+    else {
+      put(atom)
+      succeed(atom)
+    }
 
   private def findAtoms(tableName: String): DataStoreResult[List[Atom]] =
     Scanamo.scan[Atom](dynamo)(tableName).sequenceU.leftMap {

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -82,7 +82,7 @@ abstract class PreviewDynamoDataStore[D : ClassTag : DynamoFormat]
       List('contentChangeDetails, 'revision), LT, newAtom.contentChangeDetails.revision
     )
     val res = Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom))
-    res.fold(_ => Left(VersionConflictError(newAtom.contentChangeDetails.revision)), _ => Right())
+    res.fold(_ => Left(VersionConflictError(newAtom.contentChangeDetails.revision)), _ => Right(newAtom))
   }
 
 }
@@ -92,6 +92,8 @@ abstract class PublishedDynamoDataStore[D : ClassTag : DynamoFormat]
   extends DynamoDataStore[D](dynamo, tableName)
   with PublishedDataStore {
 
-  def updateAtom(newAtom: Atom) =
-    succeed(Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom)))
+  def updateAtom(newAtom: Atom) = {
+    Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom))
+    succeed(newAtom)
+  }
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -39,7 +39,8 @@ class MemoryStore extends DataStore {
              newAtom.contentChangeDetails.revision) {
           fail(VersionConflictError(newAtom.contentChangeDetails.revision))
         } else {
-          succeed(dataStore(DynamoCompositeKey(newAtom.id)) = newAtom)
+          dataStore(DynamoCompositeKey(newAtom.id)) = newAtom
+          succeed(newAtom)
         }
       case Left(_) => fail(IDNotFound)
     }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -21,13 +21,14 @@ class MemoryStore extends DataStore {
     case None => fail(IDNotFound)
   }
 
-  def createAtom(atom: Atom): DataStoreResult[Unit] = createAtom(DynamoCompositeKey(atom.id), atom)
+  def createAtom(atom: Atom): DataStoreResult[Atom] = createAtom(DynamoCompositeKey(atom.id), atom)
 
-  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Unit] = dataStore.synchronized {
+  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Atom] = dataStore.synchronized {
     if(dataStore.get(dynamoCompositeKey).isDefined) {
       fail(IDConflictError)
     } else {
-      succeed(dataStore(dynamoCompositeKey) = atom)
+      dataStore(dynamoCompositeKey) = atom
+      succeed(atom)
     }
   }
 

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -43,7 +43,7 @@ class DynamoDataStoreSpec
 
   describe("DynamoDataStore") {
     it("should create a new atom") { dataStores =>
-      dataStores.preview.createAtom(testAtom) should equal(Right())
+      dataStores.preview.createAtom(testAtom) should equal(Right(testAtom))
     }
 
     it("should return the atom") { dataStores =>
@@ -69,7 +69,7 @@ class DynamoDataStoreSpec
     }
 
     it("should create the atom with composite key") { dataStores =>
-      dataStores.compositeKey.createAtom(DynamoCompositeKey(testAtom.atomType.toString, Some(testAtom.id)), testAtom) should equal(Right())
+      dataStores.compositeKey.createAtom(DynamoCompositeKey(testAtom.atomType.toString, Some(testAtom.id)), testAtom) should equal(Right(testAtom))
     }
 
     it("should return the atom with composite key") { dataStores =>
@@ -86,13 +86,13 @@ class DynamoDataStoreSpec
     }
 
     it("should delete an atom if it exists in the table") { dataStores =>
-      dataStores.preview.createAtom(testAtomForDeletion) should equal(Right())
+      dataStores.preview.createAtom(testAtomForDeletion) should equal(Right(testAtomForDeletion))
       dataStores.preview.deleteAtom(testAtomForDeletion.id) should equal(Right(testAtomForDeletion))
     }
 
     it("should delete an atom with composite key if it exists in the table") { dataStores =>
       val key = DynamoCompositeKey(testAtomForDeletion.atomType.toString, Some(testAtomForDeletion.id))
-      dataStores.compositeKey.createAtom(key, testAtomForDeletion) should equal(Right())
+      dataStores.compositeKey.createAtom(key, testAtomForDeletion) should equal(Right(testAtomForDeletion))
       dataStores.compositeKey.deleteAtom(key) should equal(Right(testAtomForDeletion))
     }
   }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -55,7 +55,7 @@ class DynamoDataStoreSpec
         .copy(defaultHtml = "<div>updated</div>")
         .bumpRevision
 
-      dataStores.preview.updateAtom(updated) should equal(Right())
+      dataStores.preview.updateAtom(updated) should equal(Right(updated))
       dataStores.preview.getAtom(testAtom.id) should equal(Right(updated))
     }
 
@@ -64,7 +64,7 @@ class DynamoDataStoreSpec
         .copy()
         .withRevision(1)
 
-      dataStores.published.updateAtom(updated) should equal(Right())
+      dataStores.published.updateAtom(updated) should equal(Right(updated))
       dataStores.published.getAtom(testAtom.id) should equal(Right(updated))
     }
 
@@ -81,7 +81,7 @@ class DynamoDataStoreSpec
         .copy(defaultHtml = "<div>updated</div>")
         .bumpRevision
 
-      dataStores.compositeKey.updateAtom(updated) should equal(Right())
+      dataStores.compositeKey.updateAtom(updated) should equal(Right(updated))
       dataStores.compositeKey.getAtom(DynamoCompositeKey(testAtom.atomType.toString, Some(testAtom.id))) should equal(Right(updated))
     }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 // for creating test cases that use a local dynamodb
 
-addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.4.0")
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")


### PR DESCRIPTION
This is a breaking change.

Previously `createAtom` and `updateAtom` had a return type of `DataStoreResult[Unit]` which is a wrapper around an `Either`. It felt a bit side effect-y and non functional to be returning `Unit` when an atom was created or updated successfully. I've changed it so that an Atom is returned instead. This also feels a bit weird as the methods are now returning the atom that is passed in as a parameter.

It would be good to get some feedback on if changing the return type is a good idea.