### PR TITLE
Upgrade content-atom model to latest version, with new takenDown and title fields.

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
-  lazy val contentAtomVersion = "2.4.30"
+  lazy val contentAtomVersion = "2.4.33"
   lazy val scroogeVersion     = "4.12.0"
   lazy val akkaVersion        = "2.4.8"
   lazy val playVersion        = "2.5.3"


### PR DESCRIPTION
Following from https://github.com/guardian/content-atom/pull/82