### PR TITLE
Save incomplete atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,35 +7,45 @@ For the atoms to appear in capi you will also have to make necessary changes to 
 
 An example of a project that uses these libraries to manage atoms can be found [here] (https://github.com/guardian/media-atom-maker).
 
-## Atom-publisher-lib ![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/atom-publisher-lib_2.11/badge.svg)
-- Provides that traits you an inject in your application
+## Draft vs Complete Atoms
+It is possible to save incomplete atoms in a draft data store. This is done by using the automatically generated Draft data type.
+The `Draft` type has all the same fields as an Atom but all fields are now optional to allow a work in progress save to a separate data store. 
+These drafts only ever live in a data store so there is not the functionality to publish or reindex them as only complete atoms can
+be published or reindexed. Implementing a draft data store in your project is optional. The draft data types are generated from the [content atom thrift
+definition](https://github.com/guardian/content-atom) using the [Scrooge code gen sbt plugin](https://github.com/guardian/scrooge-code-gen-sbt-plugin).
 
-### PublishedStore and PreviewDataStore
+## Atom-publisher-lib ![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/atom-publisher-lib_2.11/badge.svg)
+- Provides traits to inject into your application
+
+### PublishedStore, PreviewDataStore and DraftDataStore
+- It is only necessary to implement DraftDataStore if you want to save incomplete atoms.
 - Functionality for getting, creating, listing and updating atoms
+- Functionality for getting, creating, listing and updating drafts
 - You will need to provide these with a AmazonDynamoDBClient and the names of your published and preview
 dynamo tables, and your new content atom definition.
-
+- If you will be using a draft data store you need to provide it with an AmazonDynamoDBClient and the name
+ of your draft dynamo table.
+- The data stores rely on implicits so you will need to include:
 ```
-import com.gu.contentatom.thrift._
-import com.gu.contentatom.thrift.atom.myAtom._
+import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
+import com.gu.atom.data.AtomDynamoFormats._
+import cats.syntax.either._
+```
+Otherwise you will get a `could not find implicit value` error.
 
-class PublishedMyAtomDataStoreProvider @Inject() (myConfig: AWSConfig)
-    extends Provider[PublishedDataStore] {
-        def get = new PublishedDynamoDataStore(myConfig.dynamoClient, myConfig.publishedDynamoTableName)
+#### Implementation with Compile Time Dependency Injection
+```
+import com.gu.atom.data._
+import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
+import com.gu.atom.data.AtomDynamoFormats._
+import cats.syntax.either._
+import config.Config
+
+object DataStores {
+val publishedDataStore = new PublishedDynamoDataStore(Config.dynamoClient, Config.publishedDynamoTableName)
+val previewDataStore = new PreviewDynamoDataStore(Config.dynamoClient, Config.dynamoTableName)
+val draftDataStore = new DraftDynamoDataStore(Config.dynamoDB, Config.draftDynamoTableName)
 }
-
-class PreviewMyAtomDataStoreProvider @Inject() (awsConfig: AWSConfig)
-    extends Provider[PreviewDataStore] {
-        def get = new PreviewDynamoDataStore(myConfig.dynamoClient, myConfig.dynamoTableName)
-}
-```
-
-```
-bind(classOf[PublishedDataStore])
-.toProvider(classOf[PublishedMyAtomDataStoreProvider])
-
-bind(classOf[PreviewDataStore])
-.toProvider(classOf[PreviewMyAtomDataStoreProvider])
 ```
 
 
@@ -44,19 +54,22 @@ bind(classOf[PreviewDataStore])
 Get a published atom
 ```
 publishedDataStore.getAtom(id) match {
-    case Some(atom) => //Do something with the published atom
-    case None => //Handle not finding published atom
+  case Right(atom) => //Do something with the published atom
+  case Left(e) => //Handle not finding published atom
 }
 ```
 
 Create a new atom
 ```
-previewDataStore.createAtom(atom).fold(
-    {
-      case IDConflictError => //Handle id conflict error
-      case _ => //Handle unknown error
-    },
-    _ => //Do someting with the new atom
+try {
+  val result = datastore.createAtom(buildKey(atomType, atom.id), atom)
+  result match {
+    case Right(atom) => //Do something with atom
+    case Left(e) => //Handle creation error
+  }
+} catch {
+  case e: Exception => processException(e)
+}
 
 ```
 
@@ -65,28 +78,15 @@ previewDataStore.createAtom(atom).fold(
 - You will need to provide these with a kinesis client and the names of live and preview kinesis streams
 you want to publish to and a kinesis client
 
+#### Implementation with Compile Time Dependency Injection
 ```
-import javax.inject.{Inject, Provider}
-
 import com.gu.atom.publish._
+import config.Config
 
-class LiveAtomPublisherProvider @Inject() (myConfig)
-  extends Provider[LiveAtomPublisher] {
-    def get() = new LiveKinesisAtomPublisher(myConfig.liveKinesisStreamName, myConfig.kinesisClient)
+object Publisher {
+    val liveKinesisAtomPublisher = new LiveKinesisAtomPublisher(Config.liveKinesisStreamName, Config.kinesisClient)
+    val previewKinesisAtomPublisher = new PreviewKinesisAtomPublisher(Config.previewKinesisStreamName, Config.kinesisClient)
 }
-
-  class PreviewAtomPublisherProvider @Inject() ()
-    extends Provider[PreviewAtomPublisher] {
-      def get() = new PreviewKinesisAtomPublisher(myConfig.previewKinesisStreamName, myConfig.kinesisClient)
-}
-```
-
-```
-bind(classOf[LiveAtomPublisher])
-.toProvider(classOf[LiveAtomPublisherProvider])
-
-bind(classOf[PreviewAtomPublisher])
-.toProvider(classOf[PreviewAtomPublisherProvider])
 ```
 
 #### Examples of use
@@ -109,30 +109,21 @@ previewPublisher.publishAtomEvent(event) match {
 the same as the live and preview kinesis streams.
 - `atom-manager-play-lib` provides a reindex controller utilising these (see below).
 
+#### Implementation with Compile Time Dependency Injection
 ```
-class PreviewAtomReindexerProvider @Inject() (myConfig)
-    extends Provider[PreviewAtomReindexer] {
-        def get() = new PreviewKinesisAtomReindexer(
-            myConfig.previewKinesisReindexStreamName, myConfig.kinesisClient
-        )
+import com.gu.atom.publish._
+import config.Config
+
+object ReindexDataStores {
+  val reindexPreview: PreviewKinesisAtomReindexer =
+    new PreviewKinesisAtomReindexer(Config.previewReindexKinesisStreamName, Config.kinesisClient)
+
+  val reindexPublished: PublishedKinesisAtomReindexer =
+    new PublishedKinesisAtomReindexer(Config.liveReindexKinesisStreamName, Config.kinesisClient)
 }
 
-class PublishedAtomReindexerProvider @Inject() (myConfig)
-    extends Provider[PublishedAtomReindexer] {
-        def get() = new PublishedKinesisAtomReindexer(
-            myConfig.publishedKinesisReindexStreamName, myConfig.kinesisClient
-        )
-}
-
 ```
 
-```
-bind(classOf[PreviewAtomReindexer])
-.toProvider(classOf[PreviewAtomReindexerProvider])
-
-bind(classOf[PublishedAtomReindexer])
-.toProvider(classOf[PublishedAtomReindexerProvider])
-```
 ## Atom-manager-play-lib ![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/atom-manager-play_2.11/badge.svg)
 - Sits on top of `atom-publisher-lib`
 - Provides methods for publishing and reindexing atoms
@@ -146,6 +137,18 @@ POST    /reindex-publish                com.gu.atom.play.ReindexController.newPu
 GET     /reindex-preview                com.gu.atom.play.ReindexController.previewReindexJobStatus()
 GET     /reindex-publish                com.gu.atom.play.ReindexController.publishedReindexJobStatus()
 ```
+The ReindexController also needs to be implemented and added to Routes in your AppComponents instantiation.
+```
+lazy val router = new Routes(reindex)
+
+lazy val reindex = new ReindexController(
+    previewDataStore,
+    publishedDataStore,
+    reindexPreview,
+    reindexPublished,
+    Configuration(config),
+    actorSystem)
+```
 
 ### Publishing
 - Provides a method for publishing the atom is in the `AtomAPIActions` trait.
@@ -154,6 +157,7 @@ published atoms dynamo table.
 
 In your controller:
 
+#### Implementation with Compile Time Dependency Injection
 ```
 package controllers
 
@@ -162,10 +166,10 @@ import com.gu.atom.play._
 
 //The data stores and publishers and provided by `atom-publisher-lib` library and are used by AtomAPIActions
 
-class MyAtomController @Inject()  (val previewDataStore: PreviewDataStore,
-                                   val publishedDataStore: PublishedDataStore,
-                                   val livePublisher: LiveAtomPublisher,
-                                   val previewPublisher: PreviewAtomPublisher)
+class MyAtomController (val previewDataStore: PreviewDataStore,
+                        val publishedDataStore: PublishedDataStore,
+                        val livePublisher: LiveAtomPublisher,
+                        val previewPublisher: PreviewAtomPublisher)
     extends AtomAPIActions
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ be published or reindexed. Implementing a draft data store in your project is op
 definition](https://github.com/guardian/content-atom) using the [Scrooge code gen sbt plugin](https://github.com/guardian/scrooge-code-gen-sbt-plugin).
 
 ## Atom-publisher-lib ![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/atom-publisher-lib_2.11/badge.svg)
-- Provides traits to inject into your application
+- Provides traits to include in your application
 
 ### PublishedStore, PreviewDataStore and DraftDataStore
 - It is only necessary to implement DraftDataStore if you want to save incomplete atoms.
@@ -44,7 +44,7 @@ import config.Config
 object DataStores {
 val publishedDataStore = new PublishedDynamoDataStore(Config.dynamoClient, Config.publishedDynamoTableName)
 val previewDataStore = new PreviewDynamoDataStore(Config.dynamoClient, Config.dynamoTableName)
-val draftDataStore = new DraftDynamoDataStore(Config.dynamoDB, Config.draftDynamoTableName)
+val draftDataStore = new DraftDynamoDataStore(Config.dynamoClient, Config.draftDynamoTableName)
 }
 ```
 

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -9,8 +9,6 @@ import org.scalatest.mock.MockitoSugar.mock
 import org.scalatestplus.play.PlaySpec
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule, GuiceableModuleConversions}
 import play.api.inject.{Binding, bind}
-
-import scala.collection.mutable.{Map => MMap}
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -31,5 +31,9 @@ libraryDependencies ++= Seq(
   "org.scalatest"              %% "scalatest"            % "2.2.6" % "test",
   "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test",
   "org.typelevel"              %% "cats-core"            % "0.9.0",
-  "com.github.mpilquist"       %% "simulacrum"           % "0.10.0"
+  "com.github.mpilquist"       %% "simulacrum"           % "0.10.0",
+  "com.gu"                     % "content-atom-model-thrift" % "2.4.34"
 ) ++  scanamoDeps
+
+thriftTransformThriftFiles := Seq(file("contentatom.thrift"))
+thriftTransformChangeNamespace := { (orig: String) => orig.replaceFirst("content", "draftcontent")}

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -21,17 +21,17 @@ testOptions in Test <+= dynamoDBLocalTestCleanup
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
 libraryDependencies ++= Seq(
-  "com.gu"                     %% "content-atom-model"   % contentAtomVersion,
-  "com.amazonaws"              %  "aws-java-sdk-kinesis" % awsVersion,
-  "com.typesafe.scala-logging" %% "scala-logging"        % "3.4.0",
-  "com.twitter"                %% "scrooge-serializer"   % scroogeVersion,
-  "com.twitter"                %% "scrooge-core"         % scroogeVersion,
-  "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
-  "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
-  "org.scalatest"              %% "scalatest"            % "2.2.6" % "test",
-  "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test",
-  "org.typelevel"              %% "cats-core"            % "0.9.0",
-  "com.github.mpilquist"       %% "simulacrum"           % "0.10.0",
+  "com.gu"                     %% "content-atom-model"       % contentAtomVersion,
+  "com.amazonaws"              %  "aws-java-sdk-kinesis"     % awsVersion,
+  "com.typesafe.scala-logging" %% "scala-logging"            % "3.4.0",
+  "com.twitter"                %% "scrooge-serializer"       % scroogeVersion,
+  "com.twitter"                %% "scrooge-core"             % scroogeVersion,
+  "com.typesafe.akka"          %% "akka-actor"               % akkaVersion,
+  "org.mockito"                %  "mockito-core"             % mockitoVersion % "test",
+  "org.scalatest"              %% "scalatest"                % "2.2.6" % "test",
+  "com.typesafe.akka"          %% "akka-testkit"             % akkaVersion % "test",
+  "org.typelevel"              %% "cats-core"                % "0.9.0",
+  "com.github.mpilquist"       %% "simulacrum"               % "0.10.0",
   "com.gu"                     % "content-atom-model-thrift" % "2.4.34"
 ) ++  scanamoDeps
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -18,6 +18,8 @@ startDynamoDBLocal <<= startDynamoDBLocal.dependsOn(compile in Test)
 test in Test <<= (test in Test).dependsOn(startDynamoDBLocal)
 testOptions in Test <+= dynamoDBLocalTestCleanup
 
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+
 libraryDependencies ++= Seq(
   "com.gu"                     %% "content-atom-model"   % contentAtomVersion,
   "com.amazonaws"              %  "aws-java-sdk-kinesis" % awsVersion,
@@ -28,5 +30,6 @@ libraryDependencies ++= Seq(
   "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
   "org.scalatest"              %% "scalatest"            % "2.2.6" % "test",
   "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test",
-  "org.typelevel"              %% "cats-core"            % "0.9.0"
+  "org.typelevel"              %% "cats-core"            % "0.9.0",
+  "com.github.mpilquist"       %% "simulacrum"           % "0.10.0"
 ) ++  scanamoDeps

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/AtomDynamoFormats.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/AtomDynamoFormats.scala
@@ -16,7 +16,7 @@ import com.gu.scanamo.DynamoFormat
 import com.gu.scanamo.error.{DynamoReadError, TypeCoercionError}
 import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
 
-trait AtomDynamoFormats {
+object AtomDynamoFormats {
   implicit val dynamoFormat: DynamoFormat[AtomData] = new DynamoFormat[AtomData] {
     def write(t: AtomData) = t match {
       case Quiz(_) => quizFormat.write(t)

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -41,7 +41,7 @@ trait DataStore extends DataStoreResult {
 
 object DataStore {
   @typeclass
-  trait AtomSkeleton[T] {
+  sealed trait AtomSkeleton[T] {
     def getId(atom: T): String
     def getContentChangeDetails(atom: T): ContentChangeDetails
   }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DataStore.scala
@@ -16,26 +16,28 @@ case class  ClientError(info: String) extends DataStoreError(s"Client was unable
 
 case class Draft(id: String, contentChangeDetails: ContentChangeDetails)
 
-trait DataStore[A] extends DataStoreResult {
+trait DataStore extends DataStoreResult {
 
-  def getAtom(id: String): DataStoreResult[A]
+  type DataType
 
-  def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[A]
+  def getAtom(id: String): DataStoreResult[DataType]
 
-  def createAtom(atom: A): DataStoreResult[A]
+  def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[DataType]
 
-  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: A): DataStoreResult[A]
+  def createAtom(atom: DataType): DataStoreResult[DataType]
 
-  def listAtoms: DataStoreResult[Iterator[A]]
+  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: DataType): DataStoreResult[DataType]
+
+  def listAtoms: DataStoreResult[Iterator[DataType]]
 
   /* this will only allow the update if the version in atom is later
  * than the version stored in the database, otherwise it will report
  * it as a version conflict error */
-  def updateAtom(newAtom: A): DataStoreResult[A]
+  def updateAtom(newAtom: DataType): DataStoreResult[DataType]
 
-  def deleteAtom(id: String): DataStoreResult[A]
+  def deleteAtom(id: String): DataStoreResult[DataType]
 
-  def deleteAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[A]
+  def deleteAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[DataType]
 }
 
 object DataStore {
@@ -67,8 +69,16 @@ trait DataStoreResult {
 
 object DataStoreResult extends DataStoreResult
 
-trait PreviewDataStore[A] extends DataStore[A]
+trait PreviewDataStore extends DataStore {
+  type DataType = Atom
+}
 
-trait PublishedDataStore[A] extends DataStore[A]
+trait PublishedDataStore extends DataStore {
+  type DataType = Atom
+}
+
+trait DraftDataStore extends DataStore {
+  type DataType = Draft
+}
 
 case class DynamoCompositeKey(partitionKey: String, sortKey: Option[String] = None)

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -9,24 +9,28 @@ import com.amazonaws.services.dynamodbv2.model.PutItemResult
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import com.gu.atom.data.DataStore.AtomSkeleton
 import com.gu.atom.data.ScanamoUtil.NestedKeyIs
+import com.gu.contentatom.thrift.Atom
 import com.gu.scanamo.DynamoFormat._
 import com.gu.scanamo.query._
 import com.gu.scanamo.{DynamoFormat, Scanamo, Table}
 
-abstract class DynamoDataStore[A: DynamoFormat]
-  (dynamo: AmazonDynamoDBClient, tableName: String)(implicit val atomSkeleton: AtomSkeleton[A])
-    extends DataStore[A] {
+abstract class DynamoDataStore
+  (dynamo: AmazonDynamoDBClient, tableName: String)
+    extends DataStore {
 
   sealed trait DynamoResult
+
+  val atomSkeleton: AtomSkeleton[DataType]
+  implicit val dynamoFormat: DynamoFormat[DataType]
 
   implicit class DynamoPutResult(res: PutItemResult) extends DynamoResult
 
   // useful shortcuts
-  private val get = Scanamo.get[A](dynamo)(tableName) _
-  private val put = Scanamo.put[A](dynamo)(tableName) _
+  private val get = Scanamo.get[DataType](dynamo)(tableName) _
+  private val put = Scanamo.put[DataType](dynamo)(tableName) _
   private val delete = Scanamo.delete(dynamo)(tableName) _
 
-  private def exceptionSafePut(atom: A): DataStoreResult[A] = {
+  private def exceptionSafePut(atom: DataType): DataStoreResult[DataType] = {
     try {
       put(atom)
       succeed(atom)
@@ -35,7 +39,7 @@ abstract class DynamoDataStore[A: DynamoFormat]
     }
   }
 
-  private def exceptionSafeDelete(dynamoCompositeKey :DynamoCompositeKey, atom: A): DataStoreResult[A] = {
+  private def exceptionSafeDelete(dynamoCompositeKey :DynamoCompositeKey, atom: DataType): DataStoreResult[DataType] = {
     try {
       delete(uniqueKey(dynamoCompositeKey))
       succeed(atom)
@@ -55,21 +59,21 @@ abstract class DynamoDataStore[A: DynamoFormat]
     case DynamoCompositeKey(partitionKey, Some(sortKey)) => UniqueKey(KeyEquals('atomType, partitionKey) and KeyEquals('id, sortKey))
   }
 
-  def getAtom(id: String): DataStoreResult[A] = getAtom(DynamoCompositeKey(id))
+  def getAtom(id: String): DataStoreResult[DataType] = getAtom(DynamoCompositeKey(id))
 
-  def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[A] =
+  def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[DataType] =
     get(uniqueKey(dynamoCompositeKey)) match {
       case Some(Right(atom)) => Right(atom)
       case Some(Left(error)) => Left(ReadError)
       case None => Left(IDNotFound)
     }
 
-  def createAtom(atom: A): DataStoreResult[A] = {
+  def createAtom(atom: DataType): DataStoreResult[DataType] = {
     val id = atomSkeleton.getId(atom)
     createAtom(DynamoCompositeKey(id), atom)
   }
 
-  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: A): DataStoreResult[A] =
+  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: DataType): DataStoreResult[DataType] =
     getAtom(dynamoCompositeKey) match {
       case Right(atom) =>
         fail(IDConflictError)
@@ -77,9 +81,9 @@ abstract class DynamoDataStore[A: DynamoFormat]
         exceptionSafePut(atom)
     }
 
-  def deleteAtom(id: String): DataStoreResult[A] = deleteAtom(DynamoCompositeKey(id))
+  def deleteAtom(id: String): DataStoreResult[DataType] = deleteAtom(DynamoCompositeKey(id))
 
-  def deleteAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[A] =
+  def deleteAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[DataType] =
     getAtom(dynamoCompositeKey) match {
       case Right(atom) =>
         exceptionSafeDelete(dynamoCompositeKey, atom)
@@ -87,42 +91,42 @@ abstract class DynamoDataStore[A: DynamoFormat]
         fail(error)
     }
 
-  private def findAtoms(tableName: String): DataStoreResult[List[A]] =
-    Scanamo.scan[A](dynamo)(tableName).sequenceU.leftMap {
+  private def findAtoms(tableName: String): DataStoreResult[List[DataType]] =
+    Scanamo.scan[DataType](dynamo)(tableName).sequenceU.leftMap {
       _ => ReadError
     }
 
-  def listAtoms: DataStoreResult[Iterator[A]] = findAtoms(tableName).map(_.iterator)
+  def listAtoms: DataStoreResult[Iterator[DataType]] = findAtoms(tableName).map(_.iterator)
 
 }
 
-class PreviewDynamoDataStore[A: DynamoFormat]
-(dynamo: AmazonDynamoDBClient, tableName: String)(implicit override val atomSkeleton: AtomSkeleton[A])
-  extends DynamoDataStore[A](dynamo, tableName)
-  with PreviewDataStore[A] {
+class PreviewDynamoDataStore
+(dynamo: AmazonDynamoDBClient, tableName: String)(implicit val atomSkeleton: AtomSkeleton[Atom], val dynamoFormat: DynamoFormat[Atom])
+  extends DynamoDataStore(dynamo, tableName)
+  with PreviewDataStore {
 
-  def updateAtom(newAtom: A): DataStoreResult[A] = {
+  def updateAtom(newAtom: Atom): DataStoreResult[Atom] = {
     Left(VersionConflictError(3))
 
-    val revision = atomSkeleton.getContentChangeDetails(newAtom).revision
+    val revision = newAtom.contentChangeDetails.revision
     val validationCheck = {
       NestedKeyIs(
         List('contentChangeDetails, 'revision), LT, revision
       )
     }
-    val res = Scanamo.exec(dynamo)(Table[A](tableName).given(validationCheck).put(newAtom))
+    val res = Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom))
     res.fold(_ => Left(VersionConflictError(revision)), _ => Right(newAtom))
   }
 
 }
 
-class PublishedDynamoDataStore[A: DynamoFormat]
-(dynamo: AmazonDynamoDBClient, tableName: String)(implicit override val atomSkeleton: AtomSkeleton[A])
-  extends DynamoDataStore[A](dynamo, tableName)
-  with PublishedDataStore[A] {
+class PublishedDynamoDataStore
+(dynamo: AmazonDynamoDBClient, tableName: String)(implicit val atomSkeleton: AtomSkeleton[Atom], val dynamoFormat: DynamoFormat[Atom])
+  extends DynamoDataStore(dynamo, tableName)
+  with PublishedDataStore {
 
-  def updateAtom(newAtom: A) = {
-    Scanamo.exec(dynamo)(Table[A](tableName).put(newAtom))
+  def updateAtom(newAtom: DataType) = {
+    Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom))
     succeed(newAtom)
   }
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -10,7 +10,6 @@ import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import com.gu.atom.data.DataStore.AtomSkeleton
 import com.gu.atom.data.ScanamoUtil.NestedKeyIs
 import com.gu.contentatom.thrift.Atom
-import com.gu.scanamo.DynamoFormat._
 import com.gu.scanamo.query._
 import com.gu.scanamo.{DynamoFormat, Scanamo, Table}
 import com.gu.draftcontentatom.thrift.{Atom => Draft}

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -125,8 +125,19 @@ class PublishedDynamoDataStore
   extends DynamoDataStore(dynamo, tableName)
   with PublishedDataStore {
 
-  def updateAtom(newAtom: DataType) = {
+  def updateAtom(newAtom: Atom) = {
     Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom))
+    succeed(newAtom)
+  }
+}
+
+class DraftDynamoDataStore
+(dynamo: AmazonDynamoDBClient, tableName: String)(implicit val atomSkeleton: AtomSkeleton[Draft], val dynamoFormat: DynamoFormat[Draft])
+  extends DynamoDataStore(dynamo, tableName)
+    with DraftDataStore {
+
+  def updateAtom(newAtom: Draft): DataStoreResult[Draft] = {
+    Scanamo.exec(dynamo)(Table[Draft](tableName).put(newAtom))
     succeed(newAtom)
   }
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -107,8 +107,6 @@ class PreviewDynamoDataStore
   with PreviewDataStore {
 
   def updateAtom(newAtom: Atom): DataStoreResult[Atom] = {
-    Left(VersionConflictError(3))
-
     val revision = newAtom.contentChangeDetails.revision
     val validationCheck = {
       NestedKeyIs(

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -13,6 +13,7 @@ import com.gu.contentatom.thrift.Atom
 import com.gu.scanamo.DynamoFormat._
 import com.gu.scanamo.query._
 import com.gu.scanamo.{DynamoFormat, Scanamo, Table}
+import com.gu.draftcontentatom.thrift.{Atom => Draft}
 
 abstract class DynamoDataStore
   (dynamo: AmazonDynamoDBClient, tableName: String)

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -7,27 +7,26 @@ import cats.syntax.traverse._
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.dynamodbv2.model.PutItemResult
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
-import com.gu.atom.data.ScanamoUtil._
-import com.gu.contentatom.thrift.Atom
+import com.gu.atom.data.DataStore.AtomSkeleton
+import com.gu.atom.data.ScanamoUtil.NestedKeyIs
 import com.gu.scanamo.DynamoFormat._
 import com.gu.scanamo.query._
-import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
-import com.gu.scanamo.{Scanamo, Table}
+import com.gu.scanamo.{DynamoFormat, Scanamo, Table}
 
-abstract class DynamoDataStore
-  (dynamo: AmazonDynamoDBClient, tableName: String)
-    extends DataStore with AtomDynamoFormats {
+abstract class DynamoDataStore[A: DynamoFormat]
+  (dynamo: AmazonDynamoDBClient, tableName: String)(implicit val atomSkeleton: AtomSkeleton[A])
+    extends DataStore[A] {
 
   sealed trait DynamoResult
 
   implicit class DynamoPutResult(res: PutItemResult) extends DynamoResult
 
   // useful shortcuts
-  private val get = Scanamo.get[Atom](dynamo)(tableName) _
-  private val put = Scanamo.put[Atom](dynamo)(tableName) _
+  private val get = Scanamo.get[A](dynamo)(tableName) _
+  private val put = Scanamo.put[A](dynamo)(tableName) _
   private val delete = Scanamo.delete(dynamo)(tableName) _
 
-  private def exceptionSafePut(atom: Atom): DataStoreResult[Atom] = {
+  private def exceptionSafePut(atom: A): DataStoreResult[A] = {
     try {
       put(atom)
       succeed(atom)
@@ -36,7 +35,7 @@ abstract class DynamoDataStore
     }
   }
 
-  private def exceptionSafeDelete(dynamoCompositeKey :DynamoCompositeKey, atom: Atom): DataStoreResult[Atom] = {
+  private def exceptionSafeDelete(dynamoCompositeKey :DynamoCompositeKey, atom: A): DataStoreResult[A] = {
     try {
       delete(uniqueKey(dynamoCompositeKey))
       succeed(atom)
@@ -56,18 +55,21 @@ abstract class DynamoDataStore
     case DynamoCompositeKey(partitionKey, Some(sortKey)) => UniqueKey(KeyEquals('atomType, partitionKey) and KeyEquals('id, sortKey))
   }
 
-  def getAtom(id: String): DataStoreResult[Atom] = getAtom(DynamoCompositeKey(id))
+  def getAtom(id: String): DataStoreResult[A] = getAtom(DynamoCompositeKey(id))
 
-  def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[Atom] =
+  def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[A] =
     get(uniqueKey(dynamoCompositeKey)) match {
       case Some(Right(atom)) => Right(atom)
       case Some(Left(error)) => Left(ReadError)
       case None => Left(IDNotFound)
     }
 
-  def createAtom(atom: Atom): DataStoreResult[Atom] = createAtom(DynamoCompositeKey(atom.id), atom)
+  def createAtom(atom: A): DataStoreResult[A] = {
+    val id = atomSkeleton.getId(atom)
+    createAtom(DynamoCompositeKey(id), atom)
+  }
 
-  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Atom] =
+  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: A): DataStoreResult[A] =
     getAtom(dynamoCompositeKey) match {
       case Right(atom) =>
         fail(IDConflictError)
@@ -75,9 +77,9 @@ abstract class DynamoDataStore
         exceptionSafePut(atom)
     }
 
-  def deleteAtom(id: String): DataStoreResult[Atom] = deleteAtom(DynamoCompositeKey(id))
+  def deleteAtom(id: String): DataStoreResult[A] = deleteAtom(DynamoCompositeKey(id))
 
-  def deleteAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[Atom] =
+  def deleteAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[A] =
     getAtom(dynamoCompositeKey) match {
       case Right(atom) =>
         exceptionSafeDelete(dynamoCompositeKey, atom)
@@ -85,37 +87,42 @@ abstract class DynamoDataStore
         fail(error)
     }
 
-  private def findAtoms(tableName: String): DataStoreResult[List[Atom]] =
-    Scanamo.scan[Atom](dynamo)(tableName).sequenceU.leftMap {
+  private def findAtoms(tableName: String): DataStoreResult[List[A]] =
+    Scanamo.scan[A](dynamo)(tableName).sequenceU.leftMap {
       _ => ReadError
     }
 
-  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(tableName).map(_.iterator)
+  def listAtoms: DataStoreResult[Iterator[A]] = findAtoms(tableName).map(_.iterator)
 
 }
 
-class PreviewDynamoDataStore
-(dynamo: AmazonDynamoDBClient, tableName: String)
-  extends DynamoDataStore(dynamo, tableName)
-  with PreviewDataStore {
+class PreviewDynamoDataStore[A: DynamoFormat]
+(dynamo: AmazonDynamoDBClient, tableName: String)(implicit override val atomSkeleton: AtomSkeleton[A])
+  extends DynamoDataStore[A](dynamo, tableName)
+  with PreviewDataStore[A] {
 
-  def updateAtom(newAtom: Atom) = {
-    val validationCheck = NestedKeyIs(
-      List('contentChangeDetails, 'revision), LT, newAtom.contentChangeDetails.revision
-    )
-    val res = Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom))
-    res.fold(_ => Left(VersionConflictError(newAtom.contentChangeDetails.revision)), _ => Right(newAtom))
+  def updateAtom(newAtom: A): DataStoreResult[A] = {
+    Left(VersionConflictError(3))
+
+    val revision = atomSkeleton.getContentChangeDetails(newAtom).revision
+    val validationCheck = {
+      NestedKeyIs(
+        List('contentChangeDetails, 'revision), LT, revision
+      )
+    }
+    val res = Scanamo.exec(dynamo)(Table[A](tableName).given(validationCheck).put(newAtom))
+    res.fold(_ => Left(VersionConflictError(revision)), _ => Right(newAtom))
   }
 
 }
 
-class PublishedDynamoDataStore
-(dynamo: AmazonDynamoDBClient, tableName: String)
-  extends DynamoDataStore(dynamo, tableName)
-  with PublishedDataStore {
+class PublishedDynamoDataStore[A: DynamoFormat]
+(dynamo: AmazonDynamoDBClient, tableName: String)(implicit override val atomSkeleton: AtomSkeleton[A])
+  extends DynamoDataStore[A](dynamo, tableName)
+  with PublishedDataStore[A] {
 
-  def updateAtom(newAtom: Atom) = {
-    Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom))
+  def updateAtom(newAtom: A) = {
+    Scanamo.exec(dynamo)(Table[A](tableName).put(newAtom))
     succeed(newAtom)
   }
 }

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -3,6 +3,7 @@ package data
 import com.gu.atom.data.DataStore.AtomSkeleton
 import com.gu.atom.data._
 import com.gu.contentatom.thrift.Atom
+import com.gu.draftcontentatom.thrift.{Atom => Draft}
 
 abstract class MemoryStore() extends DataStore {
 

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -5,7 +5,7 @@ import com.gu.atom.data._
 import com.gu.contentatom.thrift.Atom
 import com.gu.draftcontentatom.thrift.{Atom => Draft}
 
-abstract class MemoryStore() extends DataStore {
+abstract class MemoryStore extends DataStore {
 
   val atomSkeleton: AtomSkeleton[DataType]
 

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/MemoryStore.scala
@@ -64,3 +64,4 @@ abstract class MemoryStore() extends DataStore {
 
 class PreviewMemoryStore()(implicit override val atomSkeleton: AtomSkeleton[Atom]) extends MemoryStore() with PreviewDataStore
 class PublishedMemoryStore()(implicit override val atomSkeleton: AtomSkeleton[Atom]) extends MemoryStore() with PublishedDataStore
+class DraftDynamoMemoryStore()(implicit override val atomSkeleton: AtomSkeleton[Draft]) extends MemoryStore() with DraftDataStore

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/TestData.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/TestData.scala
@@ -5,6 +5,7 @@ import java.util.Date
 import com.gu.contentatom.thrift.atom.cta.CTAAtom
 import com.gu.contentatom.thrift.atom.media._
 import com.gu.contentatom.thrift.{ContentAtomEvent, _}
+import com.gu.draftcontentatom.thrift.{Atom => Draft, ContentChangeDetails => DraftContentChangeDetails}
 
 object TestData {
   val testAtoms = List(
@@ -124,4 +125,21 @@ object TestData {
 
   def testAtomEvent(atom: Atom = testAtom) =
     ContentAtomEvent(testAtom, EventType.Update, new Date().getTime)
+
+  val testDraftAtoms = List(
+    Draft(
+      id = Some("1"),
+      contentChangeDetails = Some(DraftContentChangeDetails(revision = Some(1)))
+    ),
+    Draft(
+      id = Some("2"),
+      contentChangeDetails = Some(DraftContentChangeDetails(revision = Some(4)))
+    ),
+    Draft(
+      id = Some("3"),
+      contentChangeDetails = Some(DraftContentChangeDetails(revision = Some(4)))
+    )
+  )
+
+  val testDraftAtom = testDraftAtoms.head
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -22,17 +22,17 @@ class DynamoDataStoreSpec
   val publishedTableName = "published-atom-test-table"
   val compositeKeyTableName = "composite-key-table"
 
-  case class DataStores(preview: PreviewDynamoDataStore[Atom],
-                        published: PublishedDynamoDataStore[Atom],
-                        compositeKey: PreviewDynamoDataStore[Atom]
+  case class DataStores(preview: PreviewDynamoDataStore,
+                        published: PublishedDynamoDataStore,
+                        compositeKey: PreviewDynamoDataStore
                        )
 
   type FixtureParam = DataStores
 
   def withFixture(test: OneArgTest) = {
-    val previewDb = new PreviewDynamoDataStore[Atom](LocalDynamoDB.client, tableName)
-    val compositeKeyDb = new PreviewDynamoDataStore[Atom](LocalDynamoDB.client, compositeKeyTableName)
-    val publishedDb = new PublishedDynamoDataStore[Atom](LocalDynamoDB.client, publishedTableName)
+    val previewDb = new PreviewDynamoDataStore(LocalDynamoDB.client, tableName)
+    val compositeKeyDb = new PreviewDynamoDataStore(LocalDynamoDB.client, compositeKeyTableName)
+    val publishedDb = new PublishedDynamoDataStore(LocalDynamoDB.client, publishedTableName)
     super.withFixture(test.toNoArgTest(DataStores(previewDb, publishedDb, compositeKeyDb)))
   }
 

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -5,10 +5,9 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import com.gu.atom.TestData._
 import com.gu.atom.util.AtomImplicitsGeneral
 import org.scalatest.{BeforeAndAfterAll, Matchers, OptionValues, fixture}
-import com.gu.atom.data.DataStore._
-import com.gu.contentatom.thrift.Atom
+import com.gu.draftcontentatom.thrift.{Atom => Draft}
+
 import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
-import com.gu.scanamo.DynamoFormat._
 import com.gu.atom.data.AtomDynamoFormats._
 
 class DynamoDataStoreSpec
@@ -21,10 +20,12 @@ class DynamoDataStoreSpec
   val tableName = "atom-test-table"
   val publishedTableName = "published-atom-test-table"
   val compositeKeyTableName = "composite-key-table"
+  val draftTableName = "draft-atom-test-table"
 
   case class DataStores(preview: PreviewDynamoDataStore,
                         published: PublishedDynamoDataStore,
-                        compositeKey: PreviewDynamoDataStore
+                        compositeKey: PreviewDynamoDataStore,
+                        draft: DraftDynamoDataStore
                        )
 
   type FixtureParam = DataStores
@@ -33,7 +34,8 @@ class DynamoDataStoreSpec
     val previewDb = new PreviewDynamoDataStore(LocalDynamoDB.client, tableName)
     val compositeKeyDb = new PreviewDynamoDataStore(LocalDynamoDB.client, compositeKeyTableName)
     val publishedDb = new PublishedDynamoDataStore(LocalDynamoDB.client, publishedTableName)
-    super.withFixture(test.toNoArgTest(DataStores(previewDb, publishedDb, compositeKeyDb)))
+    val draftDb = new DraftDynamoDataStore(LocalDynamoDB.client, draftTableName)
+    super.withFixture(test.toNoArgTest(DataStores(previewDb, publishedDb, compositeKeyDb, draftDb)))
   }
 
   describe("DynamoDataStore") {
@@ -96,6 +98,27 @@ class DynamoDataStoreSpec
       dataStores.compositeKey.createAtom(key, testAtomForDeletion) should equal(Right(testAtomForDeletion))
       dataStores.compositeKey.deleteAtom(key) should equal(Right(testAtomForDeletion))
     }
+
+    it("should create a new draft atom") { dataStores =>
+      dataStores.draft.createAtom(testDraftAtom) should equal(Right(testDraftAtom))
+    }
+
+    it("should list all draft atoms") { dataStores =>
+      dataStores.draft.createAtom(testDraftAtoms(1))
+      dataStores.draft.createAtom(testDraftAtoms(2))
+      dataStores.draft.listAtoms.map(_.toList).fold(identity, res => res should contain theSameElementsAs testDraftAtoms)
+    }
+
+    it("should return a specific draft atom") { dataStores =>
+      dataStores.draft.getAtom(testDraftAtom.id.get) should equal(Right(testDraftAtom))
+    }
+
+    it("should update the draft atom") { dataStores =>
+      val updated: Draft = testDraftAtom.copy(defaultHtml = Some("<div>updated</div>"))
+
+      dataStores.draft.updateAtom(updated) should equal(Right(updated))
+      dataStores.draft.getAtom(testDraftAtom.id.get) should equal(Right(updated))
+    }
   }
 
   override def beforeAll() = {
@@ -103,5 +126,6 @@ class DynamoDataStoreSpec
     LocalDynamoDB.createTable(client)(tableName)('id -> S)
     LocalDynamoDB.createTable(client)(publishedTableName)('id -> S)
     LocalDynamoDB.createTable(client)(compositeKeyTableName)('atomType -> S, 'id -> S)
+    LocalDynamoDB.createTable(client)(draftTableName)('id -> S)
   }
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -5,6 +5,11 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import com.gu.atom.TestData._
 import com.gu.atom.util.AtomImplicitsGeneral
 import org.scalatest.{BeforeAndAfterAll, Matchers, OptionValues, fixture}
+import com.gu.atom.data.DataStore._
+import com.gu.contentatom.thrift.Atom
+import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
+import com.gu.scanamo.DynamoFormat._
+import com.gu.atom.data.AtomDynamoFormats._
 
 class DynamoDataStoreSpec
     extends fixture.FunSpec
@@ -17,17 +22,17 @@ class DynamoDataStoreSpec
   val publishedTableName = "published-atom-test-table"
   val compositeKeyTableName = "composite-key-table"
 
-  case class DataStores(preview: PreviewDynamoDataStore,
-                        published: PublishedDynamoDataStore,
-                        compositeKey: PreviewDynamoDataStore
+  case class DataStores(preview: PreviewDynamoDataStore[Atom],
+                        published: PublishedDynamoDataStore[Atom],
+                        compositeKey: PreviewDynamoDataStore[Atom]
                        )
 
   type FixtureParam = DataStores
 
   def withFixture(test: OneArgTest) = {
-    val previewDb = new PreviewDynamoDataStore(LocalDynamoDB.client, tableName)
-    val compositeKeyDb = new PreviewDynamoDataStore(LocalDynamoDB.client, compositeKeyTableName)
-    val publishedDb = new PublishedDynamoDataStore(LocalDynamoDB.client, publishedTableName)
+    val previewDb = new PreviewDynamoDataStore[Atom](LocalDynamoDB.client, tableName)
+    val compositeKeyDb = new PreviewDynamoDataStore[Atom](LocalDynamoDB.client, compositeKeyTableName)
+    val publishedDb = new PublishedDynamoDataStore[Atom](LocalDynamoDB.client, publishedTableName)
     super.withFixture(test.toNoArgTest(DataStores(previewDb, publishedDb, compositeKeyDb)))
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val atomPublisher = (project in file("./atom-publisher-lib"))
 
 
 lazy val atomManagerPlay = (project in file("./atom-manager-play-lib"))
+  .disablePlugins(ThriftTransformerSBT)
   .settings(baseSettings: _*)
   .settings(
     organization := "com.gu",
@@ -32,6 +33,7 @@ lazy val atomManagerPlay = (project in file("./atom-manager-play-lib"))
   .dependsOn(atomPublisher % "test->test;compile->compile")
 
 lazy val atomLibraries = (project in file("."))
+  .disablePlugins(ThriftTransformerSBT)
   .aggregate(atomPublisher, atomManagerPlay)
   .settings(baseSettings: _*).settings(
   publishArtifact := false,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 // for creating test cases that use a local dynamodb
 
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")
+
+addSbtPlugin("com.gu" % "thrift-transformer-sbt" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,4 +16,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")
 
-addSbtPlugin("com.gu" % "thrift-transformer-sbt" % "1.0.0")
+addSbtPlugin("com.gu" % "thrift-transformer-sbt" % "1.0.1")


### PR DESCRIPTION
#### Problem: 
Some atom types have lots of fields. We want to be able to save an atom when not all the required fields have been filled in so that the user can come back and continue editing later.

#### Solution:
We now have a new data type 'Draft'. This comes from the [scrooge-code-gen-plugin](https://github.com/guardian/scrooge-code-gen-sbt-plugin) which generates case classes based on the [content atom thrift definitions](https://github.com/guardian/content-atom) but unlike the `Atom` case classes generated from the thrift all fields are optional. This PR uses these generated case classes and makes the code more general so that both Drafts (atoms with all optional fields) and Atoms can be saved into a DynamoDB database. There are now 3 Datastore traits that users of the library can choose to implement. A datastore for Preview Atoms another for Published Atoms and another for Drafts.

No changes have been made to the publishing or reindexing process to include this new type as Drafts will never be sent to CAPI as they are not complete and the fields marked as required in the thrift definition will not necessarily have been set.

#### Note:
The case classes generated by the plugin will use the same names as the `Atom` case classes generated from the thrift definition. To avoid naming conflicts they have been mapped to `Draft` when imported and the generated code from the plugin is put into the `com.gu.draftcontentatom.thrift` namespace.