### PR TITLE
Take drafts out of atom maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,45 +7,35 @@ For the atoms to appear in capi you will also have to make necessary changes to 
 
 An example of a project that uses these libraries to manage atoms can be found [here] (https://github.com/guardian/media-atom-maker).
 
-## Draft vs Complete Atoms
-It is possible to save incomplete atoms in a draft data store. This is done by using the automatically generated Draft data type.
-The `Draft` type has all the same fields as an Atom but all fields are now optional to allow a work in progress save to a separate data store. 
-These drafts only ever live in a data store so there is not the functionality to publish or reindex them as only complete atoms can
-be published or reindexed. Implementing a draft data store in your project is optional. The draft data types are generated from the [content atom thrift
-definition](https://github.com/guardian/content-atom) using the [Scrooge code gen sbt plugin](https://github.com/guardian/scrooge-code-gen-sbt-plugin).
-
 ## Atom-publisher-lib ![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/atom-publisher-lib_2.11/badge.svg)
-- Provides traits to include in your application
+- Provides that traits you an inject in your application
 
-### PublishedStore, PreviewDataStore and DraftDataStore
-- It is only necessary to implement DraftDataStore if you want to save incomplete atoms.
+### PublishedStore and PreviewDataStore
 - Functionality for getting, creating, listing and updating atoms
-- Functionality for getting, creating, listing and updating drafts
 - You will need to provide these with a AmazonDynamoDBClient and the names of your published and preview
 dynamo tables, and your new content atom definition.
-- If you will be using a draft data store you need to provide it with an AmazonDynamoDBClient and the name
- of your draft dynamo table.
-- The data stores rely on implicits so you will need to include:
-```
-import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
-import com.gu.atom.data.AtomDynamoFormats._
-import cats.syntax.either._
-```
-Otherwise you will get a `could not find implicit value` error.
 
-#### Implementation with Compile Time Dependency Injection
 ```
-import com.gu.atom.data._
-import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
-import com.gu.atom.data.AtomDynamoFormats._
-import cats.syntax.either._
-import config.Config
+import com.gu.contentatom.thrift._
+import com.gu.contentatom.thrift.atom.myAtom._
 
-object DataStores {
-val publishedDataStore = new PublishedDynamoDataStore(Config.dynamoClient, Config.publishedDynamoTableName)
-val previewDataStore = new PreviewDynamoDataStore(Config.dynamoClient, Config.dynamoTableName)
-val draftDataStore = new DraftDynamoDataStore(Config.dynamoClient, Config.draftDynamoTableName)
+class PublishedMyAtomDataStoreProvider @Inject() (myConfig: AWSConfig)
+    extends Provider[PublishedDataStore] {
+        def get = new PublishedDynamoDataStore(myConfig.dynamoClient, myConfig.publishedDynamoTableName)
 }
+
+class PreviewMyAtomDataStoreProvider @Inject() (awsConfig: AWSConfig)
+    extends Provider[PreviewDataStore] {
+        def get = new PreviewDynamoDataStore(myConfig.dynamoClient, myConfig.dynamoTableName)
+}
+```
+
+```
+bind(classOf[PublishedDataStore])
+.toProvider(classOf[PublishedMyAtomDataStoreProvider])
+
+bind(classOf[PreviewDataStore])
+.toProvider(classOf[PreviewMyAtomDataStoreProvider])
 ```
 
 
@@ -54,22 +44,19 @@ val draftDataStore = new DraftDynamoDataStore(Config.dynamoClient, Config.draftD
 Get a published atom
 ```
 publishedDataStore.getAtom(id) match {
-  case Right(atom) => //Do something with the published atom
-  case Left(e) => //Handle not finding published atom
+    case Some(atom) => //Do something with the published atom
+    case None => //Handle not finding published atom
 }
 ```
 
 Create a new atom
 ```
-try {
-  val result = datastore.createAtom(buildKey(atomType, atom.id), atom)
-  result match {
-    case Right(atom) => //Do something with atom
-    case Left(e) => //Handle creation error
-  }
-} catch {
-  case e: Exception => processException(e)
-}
+previewDataStore.createAtom(atom).fold(
+    {
+      case IDConflictError => //Handle id conflict error
+      case _ => //Handle unknown error
+    },
+    _ => //Do someting with the new atom
 
 ```
 
@@ -78,15 +65,28 @@ try {
 - You will need to provide these with a kinesis client and the names of live and preview kinesis streams
 you want to publish to and a kinesis client
 
-#### Implementation with Compile Time Dependency Injection
 ```
-import com.gu.atom.publish._
-import config.Config
+import javax.inject.{Inject, Provider}
 
-object Publisher {
-    val liveKinesisAtomPublisher = new LiveKinesisAtomPublisher(Config.liveKinesisStreamName, Config.kinesisClient)
-    val previewKinesisAtomPublisher = new PreviewKinesisAtomPublisher(Config.previewKinesisStreamName, Config.kinesisClient)
+import com.gu.atom.publish._
+
+class LiveAtomPublisherProvider @Inject() (myConfig)
+  extends Provider[LiveAtomPublisher] {
+    def get() = new LiveKinesisAtomPublisher(myConfig.liveKinesisStreamName, myConfig.kinesisClient)
 }
+
+  class PreviewAtomPublisherProvider @Inject() ()
+    extends Provider[PreviewAtomPublisher] {
+      def get() = new PreviewKinesisAtomPublisher(myConfig.previewKinesisStreamName, myConfig.kinesisClient)
+}
+```
+
+```
+bind(classOf[LiveAtomPublisher])
+.toProvider(classOf[LiveAtomPublisherProvider])
+
+bind(classOf[PreviewAtomPublisher])
+.toProvider(classOf[PreviewAtomPublisherProvider])
 ```
 
 #### Examples of use
@@ -109,21 +109,30 @@ previewPublisher.publishAtomEvent(event) match {
 the same as the live and preview kinesis streams.
 - `atom-manager-play-lib` provides a reindex controller utilising these (see below).
 
-#### Implementation with Compile Time Dependency Injection
 ```
-import com.gu.atom.publish._
-import config.Config
+class PreviewAtomReindexerProvider @Inject() (myConfig)
+    extends Provider[PreviewAtomReindexer] {
+        def get() = new PreviewKinesisAtomReindexer(
+            myConfig.previewKinesisReindexStreamName, myConfig.kinesisClient
+        )
+}
 
-object ReindexDataStores {
-  val reindexPreview: PreviewKinesisAtomReindexer =
-    new PreviewKinesisAtomReindexer(Config.previewReindexKinesisStreamName, Config.kinesisClient)
-
-  val reindexPublished: PublishedKinesisAtomReindexer =
-    new PublishedKinesisAtomReindexer(Config.liveReindexKinesisStreamName, Config.kinesisClient)
+class PublishedAtomReindexerProvider @Inject() (myConfig)
+    extends Provider[PublishedAtomReindexer] {
+        def get() = new PublishedKinesisAtomReindexer(
+            myConfig.publishedKinesisReindexStreamName, myConfig.kinesisClient
+        )
 }
 
 ```
 
+```
+bind(classOf[PreviewAtomReindexer])
+.toProvider(classOf[PreviewAtomReindexerProvider])
+
+bind(classOf[PublishedAtomReindexer])
+.toProvider(classOf[PublishedAtomReindexerProvider])
+```
 ## Atom-manager-play-lib ![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/atom-manager-play_2.11/badge.svg)
 - Sits on top of `atom-publisher-lib`
 - Provides methods for publishing and reindexing atoms
@@ -137,18 +146,6 @@ POST    /reindex-publish                com.gu.atom.play.ReindexController.newPu
 GET     /reindex-preview                com.gu.atom.play.ReindexController.previewReindexJobStatus()
 GET     /reindex-publish                com.gu.atom.play.ReindexController.publishedReindexJobStatus()
 ```
-The ReindexController also needs to be implemented and added to Routes in your AppComponents instantiation.
-```
-lazy val router = new Routes(reindex)
-
-lazy val reindex = new ReindexController(
-    previewDataStore,
-    publishedDataStore,
-    reindexPreview,
-    reindexPublished,
-    Configuration(config),
-    actorSystem)
-```
 
 ### Publishing
 - Provides a method for publishing the atom is in the `AtomAPIActions` trait.
@@ -157,7 +154,6 @@ published atoms dynamo table.
 
 In your controller:
 
-#### Implementation with Compile Time Dependency Injection
 ```
 package controllers
 
@@ -166,10 +162,10 @@ import com.gu.atom.play._
 
 //The data stores and publishers and provided by `atom-publisher-lib` library and are used by AtomAPIActions
 
-class MyAtomController (val previewDataStore: PreviewDataStore,
-                        val publishedDataStore: PublishedDataStore,
-                        val livePublisher: LiveAtomPublisher,
-                        val previewPublisher: PreviewAtomPublisher)
+class MyAtomController @Inject()  (val previewDataStore: PreviewDataStore,
+                                   val publishedDataStore: PublishedDataStore,
+                                   val livePublisher: LiveAtomPublisher,
+                                   val previewPublisher: PreviewAtomPublisher)
     extends AtomAPIActions
 ```
 

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -9,6 +9,8 @@ import org.scalatest.mock.MockitoSugar.mock
 import org.scalatestplus.play.PlaySpec
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule, GuiceableModuleConversions}
 import play.api.inject.{Binding, bind}
+
+import scala.collection.mutable.{Map => MMap}
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -18,22 +18,15 @@ startDynamoDBLocal <<= startDynamoDBLocal.dependsOn(compile in Test)
 test in Test <<= (test in Test).dependsOn(startDynamoDBLocal)
 testOptions in Test <+= dynamoDBLocalTestCleanup
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-
 libraryDependencies ++= Seq(
-  "com.gu"                     %% "content-atom-model"       % contentAtomVersion,
-  "com.amazonaws"              %  "aws-java-sdk-kinesis"     % awsVersion,
-  "com.typesafe.scala-logging" %% "scala-logging"            % "3.4.0",
-  "com.twitter"                %% "scrooge-serializer"       % scroogeVersion,
-  "com.twitter"                %% "scrooge-core"             % scroogeVersion,
-  "com.typesafe.akka"          %% "akka-actor"               % akkaVersion,
-  "org.mockito"                %  "mockito-core"             % mockitoVersion % "test",
-  "org.scalatest"              %% "scalatest"                % "2.2.6" % "test",
-  "com.typesafe.akka"          %% "akka-testkit"             % akkaVersion % "test",
-  "org.typelevel"              %% "cats-core"                % "0.9.0",
-  "com.github.mpilquist"       %% "simulacrum"               % "0.10.0",
-  "com.gu"                     % "content-atom-model-thrift" % "2.4.34"
+  "com.gu"                     %% "content-atom-model"   % contentAtomVersion,
+  "com.amazonaws"              %  "aws-java-sdk-kinesis" % awsVersion,
+  "com.typesafe.scala-logging" %% "scala-logging"        % "3.4.0",
+  "com.twitter"                %% "scrooge-serializer"   % scroogeVersion,
+  "com.twitter"                %% "scrooge-core"         % scroogeVersion,
+  "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
+  "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
+  "org.scalatest"              %% "scalatest"            % "2.2.6" % "test",
+  "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test",
+  "org.typelevel"              %% "cats-core"            % "0.9.0"
 ) ++  scanamoDeps
-
-thriftTransformThriftFiles := Seq(file("contentatom.thrift"))
-thriftTransformChangeNamespace := { (orig: String) => orig.replaceFirst("content", "draftcontent")}

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/AtomDynamoFormats.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/AtomDynamoFormats.scala
@@ -16,7 +16,7 @@ import com.gu.scanamo.DynamoFormat
 import com.gu.scanamo.error.{DynamoReadError, TypeCoercionError}
 import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
 
-object AtomDynamoFormats {
+trait AtomDynamoFormats {
   implicit val dynamoFormat: DynamoFormat[AtomData] = new DynamoFormat[AtomData] {
     def write(t: AtomData) = t match {
       case Quiz(_) => quizFormat.write(t)

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -7,30 +7,27 @@ import cats.syntax.traverse._
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.dynamodbv2.model.PutItemResult
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
-import com.gu.atom.data.DataStore.AtomSkeleton
-import com.gu.atom.data.ScanamoUtil.NestedKeyIs
+import com.gu.atom.data.ScanamoUtil._
 import com.gu.contentatom.thrift.Atom
+import com.gu.scanamo.DynamoFormat._
 import com.gu.scanamo.query._
-import com.gu.scanamo.{DynamoFormat, Scanamo, Table}
-import com.gu.draftcontentatom.thrift.{Atom => Draft}
+import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
+import com.gu.scanamo.{Scanamo, Table}
 
 abstract class DynamoDataStore
   (dynamo: AmazonDynamoDBClient, tableName: String)
-    extends DataStore {
+    extends DataStore with AtomDynamoFormats {
 
   sealed trait DynamoResult
-
-  val atomSkeleton: AtomSkeleton[DataType]
-  implicit val dynamoFormat: DynamoFormat[DataType]
 
   implicit class DynamoPutResult(res: PutItemResult) extends DynamoResult
 
   // useful shortcuts
-  private val get = Scanamo.get[DataType](dynamo)(tableName) _
-  private val put = Scanamo.put[DataType](dynamo)(tableName) _
+  private val get = Scanamo.get[Atom](dynamo)(tableName) _
+  private val put = Scanamo.put[Atom](dynamo)(tableName) _
   private val delete = Scanamo.delete(dynamo)(tableName) _
 
-  private def exceptionSafePut(atom: DataType): DataStoreResult[DataType] = {
+  private def exceptionSafePut(atom: Atom): DataStoreResult[Atom] = {
     try {
       put(atom)
       succeed(atom)
@@ -39,7 +36,7 @@ abstract class DynamoDataStore
     }
   }
 
-  private def exceptionSafeDelete(dynamoCompositeKey :DynamoCompositeKey, atom: DataType): DataStoreResult[DataType] = {
+  private def exceptionSafeDelete(dynamoCompositeKey :DynamoCompositeKey, atom: Atom): DataStoreResult[Atom] = {
     try {
       delete(uniqueKey(dynamoCompositeKey))
       succeed(atom)
@@ -59,21 +56,18 @@ abstract class DynamoDataStore
     case DynamoCompositeKey(partitionKey, Some(sortKey)) => UniqueKey(KeyEquals('atomType, partitionKey) and KeyEquals('id, sortKey))
   }
 
-  def getAtom(id: String): DataStoreResult[DataType] = getAtom(DynamoCompositeKey(id))
+  def getAtom(id: String): DataStoreResult[Atom] = getAtom(DynamoCompositeKey(id))
 
-  def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[DataType] =
+  def getAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[Atom] =
     get(uniqueKey(dynamoCompositeKey)) match {
       case Some(Right(atom)) => Right(atom)
       case Some(Left(error)) => Left(ReadError)
       case None => Left(IDNotFound)
     }
 
-  def createAtom(atom: DataType): DataStoreResult[DataType] = {
-    val id = atomSkeleton.getId(atom)
-    createAtom(DynamoCompositeKey(id), atom)
-  }
+  def createAtom(atom: Atom): DataStoreResult[Atom] = createAtom(DynamoCompositeKey(atom.id), atom)
 
-  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: DataType): DataStoreResult[DataType] =
+  def createAtom(dynamoCompositeKey: DynamoCompositeKey, atom: Atom): DataStoreResult[Atom] =
     getAtom(dynamoCompositeKey) match {
       case Right(atom) =>
         fail(IDConflictError)
@@ -81,9 +75,9 @@ abstract class DynamoDataStore
         exceptionSafePut(atom)
     }
 
-  def deleteAtom(id: String): DataStoreResult[DataType] = deleteAtom(DynamoCompositeKey(id))
+  def deleteAtom(id: String): DataStoreResult[Atom] = deleteAtom(DynamoCompositeKey(id))
 
-  def deleteAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[DataType] =
+  def deleteAtom(dynamoCompositeKey: DynamoCompositeKey): DataStoreResult[Atom] =
     getAtom(dynamoCompositeKey) match {
       case Right(atom) =>
         exceptionSafeDelete(dynamoCompositeKey, atom)
@@ -91,51 +85,37 @@ abstract class DynamoDataStore
         fail(error)
     }
 
-  private def findAtoms(tableName: String): DataStoreResult[List[DataType]] =
-    Scanamo.scan[DataType](dynamo)(tableName).sequenceU.leftMap {
+  private def findAtoms(tableName: String): DataStoreResult[List[Atom]] =
+    Scanamo.scan[Atom](dynamo)(tableName).sequenceU.leftMap {
       _ => ReadError
     }
 
-  def listAtoms: DataStoreResult[Iterator[DataType]] = findAtoms(tableName).map(_.iterator)
+  def listAtoms: DataStoreResult[Iterator[Atom]] = findAtoms(tableName).map(_.iterator)
 
 }
 
 class PreviewDynamoDataStore
-(dynamo: AmazonDynamoDBClient, tableName: String)(implicit val atomSkeleton: AtomSkeleton[Atom], val dynamoFormat: DynamoFormat[Atom])
+(dynamo: AmazonDynamoDBClient, tableName: String)
   extends DynamoDataStore(dynamo, tableName)
   with PreviewDataStore {
 
-  def updateAtom(newAtom: Atom): DataStoreResult[Atom] = {
-    val revision = newAtom.contentChangeDetails.revision
-    val validationCheck = {
-      NestedKeyIs(
-        List('contentChangeDetails, 'revision), LT, revision
-      )
-    }
+  def updateAtom(newAtom: Atom) = {
+    val validationCheck = NestedKeyIs(
+      List('contentChangeDetails, 'revision), LT, newAtom.contentChangeDetails.revision
+    )
     val res = Scanamo.exec(dynamo)(Table[Atom](tableName).given(validationCheck).put(newAtom))
-    res.fold(_ => Left(VersionConflictError(revision)), _ => Right(newAtom))
+    res.fold(_ => Left(VersionConflictError(newAtom.contentChangeDetails.revision)), _ => Right(newAtom))
   }
 
 }
 
 class PublishedDynamoDataStore
-(dynamo: AmazonDynamoDBClient, tableName: String)(implicit val atomSkeleton: AtomSkeleton[Atom], val dynamoFormat: DynamoFormat[Atom])
+(dynamo: AmazonDynamoDBClient, tableName: String)
   extends DynamoDataStore(dynamo, tableName)
   with PublishedDataStore {
 
-  def updateAtom(newAtom: DataType) = {
+  def updateAtom(newAtom: Atom) = {
     Scanamo.exec(dynamo)(Table[Atom](tableName).put(newAtom))
-    succeed(newAtom)
-  }
-}
-
-class DraftDynamoDataStore
-(dynamo: AmazonDynamoDBClient, tableName: String)(implicit val atomSkeleton: AtomSkeleton[Draft], val dynamoFormat: DynamoFormat[Draft])
-  extends DynamoDataStore(dynamo, tableName)
-    with DraftDataStore {
-
-  def updateAtom(newAtom: Draft): DataStoreResult[Draft] = {
-    Scanamo.exec(dynamo)(Table[Draft](tableName).put(newAtom))
     succeed(newAtom)
   }
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/TestData.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/TestData.scala
@@ -5,7 +5,6 @@ import java.util.Date
 import com.gu.contentatom.thrift.atom.cta.CTAAtom
 import com.gu.contentatom.thrift.atom.media._
 import com.gu.contentatom.thrift.{ContentAtomEvent, _}
-import com.gu.draftcontentatom.thrift.{Atom => Draft, ContentChangeDetails => DraftContentChangeDetails}
 
 object TestData {
   val testAtoms = List(
@@ -125,21 +124,4 @@ object TestData {
 
   def testAtomEvent(atom: Atom = testAtom) =
     ContentAtomEvent(testAtom, EventType.Update, new Date().getTime)
-
-  val testDraftAtoms = List(
-    Draft(
-      id = Some("1"),
-      contentChangeDetails = Some(DraftContentChangeDetails(revision = Some(1)))
-    ),
-    Draft(
-      id = Some("2"),
-      contentChangeDetails = Some(DraftContentChangeDetails(revision = Some(4)))
-    ),
-    Draft(
-      id = Some("3"),
-      contentChangeDetails = Some(DraftContentChangeDetails(revision = Some(4)))
-    )
-  )
-
-  val testDraftAtom = testDraftAtoms.head
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -5,10 +5,6 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import com.gu.atom.TestData._
 import com.gu.atom.util.AtomImplicitsGeneral
 import org.scalatest.{BeforeAndAfterAll, Matchers, OptionValues, fixture}
-import com.gu.draftcontentatom.thrift.{Atom => Draft}
-
-import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
-import com.gu.atom.data.AtomDynamoFormats._
 
 class DynamoDataStoreSpec
     extends fixture.FunSpec
@@ -20,12 +16,10 @@ class DynamoDataStoreSpec
   val tableName = "atom-test-table"
   val publishedTableName = "published-atom-test-table"
   val compositeKeyTableName = "composite-key-table"
-  val draftTableName = "draft-atom-test-table"
 
   case class DataStores(preview: PreviewDynamoDataStore,
                         published: PublishedDynamoDataStore,
-                        compositeKey: PreviewDynamoDataStore,
-                        draft: DraftDynamoDataStore
+                        compositeKey: PreviewDynamoDataStore
                        )
 
   type FixtureParam = DataStores
@@ -34,8 +28,7 @@ class DynamoDataStoreSpec
     val previewDb = new PreviewDynamoDataStore(LocalDynamoDB.client, tableName)
     val compositeKeyDb = new PreviewDynamoDataStore(LocalDynamoDB.client, compositeKeyTableName)
     val publishedDb = new PublishedDynamoDataStore(LocalDynamoDB.client, publishedTableName)
-    val draftDb = new DraftDynamoDataStore(LocalDynamoDB.client, draftTableName)
-    super.withFixture(test.toNoArgTest(DataStores(previewDb, publishedDb, compositeKeyDb, draftDb)))
+    super.withFixture(test.toNoArgTest(DataStores(previewDb, publishedDb, compositeKeyDb)))
   }
 
   describe("DynamoDataStore") {
@@ -98,27 +91,6 @@ class DynamoDataStoreSpec
       dataStores.compositeKey.createAtom(key, testAtomForDeletion) should equal(Right(testAtomForDeletion))
       dataStores.compositeKey.deleteAtom(key) should equal(Right(testAtomForDeletion))
     }
-
-    it("should create a new draft atom") { dataStores =>
-      dataStores.draft.createAtom(testDraftAtom) should equal(Right(testDraftAtom))
-    }
-
-    it("should list all draft atoms") { dataStores =>
-      dataStores.draft.createAtom(testDraftAtoms(1))
-      dataStores.draft.createAtom(testDraftAtoms(2))
-      dataStores.draft.listAtoms.map(_.toList).fold(identity, res => res should contain theSameElementsAs testDraftAtoms)
-    }
-
-    it("should return a specific draft atom") { dataStores =>
-      dataStores.draft.getAtom(testDraftAtom.id.get) should equal(Right(testDraftAtom))
-    }
-
-    it("should update the draft atom") { dataStores =>
-      val updated: Draft = testDraftAtom.copy(defaultHtml = Some("<div>updated</div>"))
-
-      dataStores.draft.updateAtom(updated) should equal(Right(updated))
-      dataStores.draft.getAtom(testDraftAtom.id.get) should equal(Right(updated))
-    }
   }
 
   override def beforeAll() = {
@@ -126,6 +98,5 @@ class DynamoDataStoreSpec
     LocalDynamoDB.createTable(client)(tableName)('id -> S)
     LocalDynamoDB.createTable(client)(publishedTableName)('id -> S)
     LocalDynamoDB.createTable(client)(compositeKeyTableName)('atomType -> S, 'id -> S)
-    LocalDynamoDB.createTable(client)(draftTableName)('id -> S)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ lazy val atomPublisher = (project in file("./atom-publisher-lib"))
 
 
 lazy val atomManagerPlay = (project in file("./atom-manager-play-lib"))
-  .disablePlugins(ThriftTransformerSBT)
   .settings(baseSettings: _*)
   .settings(
     organization := "com.gu",
@@ -33,7 +32,6 @@ lazy val atomManagerPlay = (project in file("./atom-manager-play-lib"))
   .dependsOn(atomPublisher % "test->test;compile->compile")
 
 lazy val atomLibraries = (project in file("."))
-  .disablePlugins(ThriftTransformerSBT)
   .aggregate(atomPublisher, atomManagerPlay)
   .settings(baseSettings: _*).settings(
   publishArtifact := false,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,5 +15,3 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 // for creating test cases that use a local dynamodb
 
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")
-
-addSbtPlugin("com.gu" % "thrift-transformer-sbt" % "1.0.3")


### PR DESCRIPTION
Currently unclear if we are going to have draft atoms or if we are going to be able to provide sensible default values in the thrift definition instead. Currently work is being done to determine for each atom in the [thrift definition](https://github.com/guardian/content-atom/tree/master/thrift/src/main/thrift) if fields:
1. can be optional or,
2. can be populated with a _sensible_ default value that makes sense for publication

This change is being removed as it is currently blocking introducing new behaviour to the library. If it turns out that we cannot use the thrift definition this work can be reintroduced.