### PR TITLE
Atom model 2.4.60

### DIFF
--- a/atom-publisher-lib/src/main/scala/com/gu/atom/util/JsonSupport.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/util/JsonSupport.scala
@@ -66,7 +66,8 @@ object JsonSupport {
         val fixedJson = {
           val nestedDataFieldName = atomType.toLowerCase
 
-          if (data(nestedDataFieldName).nonEmpty) c.value
+          //Special case for commonsDivision because the scrooge enum value loses the casing
+          if (data(nestedDataFieldName).nonEmpty || nestedDataFieldName == "commonsdivision") c.value
           else {
             //Add the union type name under `data`
             val newData = JsonObject.fromIterable(Seq(nestedDataFieldName -> dataJson))

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
-  lazy val contentAtomVersion = "2.4.59"
+  lazy val contentAtomVersion = "2.4.60"
   lazy val scroogeVersion     = "4.18.0"
   lazy val akkaVersion        = "2.4.8"
   lazy val playVersion        = "2.5.3"


### PR DESCRIPTION
also a change to the backwards-compatible decoder, because the enum value (Commonsdivision) is different to the field name (commonsDivision)