### PR TITLE
Bump version of Content Atom

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
-  lazy val contentAtomVersion = "2.4.60"
+  lazy val contentAtomVersion = "2.4.61"
   lazy val scroogeVersion     = "4.18.0"
   lazy val akkaVersion        = "2.4.8"
   lazy val playVersion        = "2.5.3"


### PR DESCRIPTION
Because we have updated the Thrift models in Content-Atom: 
We need to pull in the latest version so this passes onto Atom Workshop. 

Change in [Content Atom](https://github.com/guardian/content-atom/pull/121)

Version bump in [Content Atom](https://github.com/guardian/content-atom/commit/107966860b19f510ff5bb0f4c5c7d9cf619033a7)

[Trello Ticket ](https://trello.com/c/GexFvYIf/240-add-new-fields-for-atom-images-adding-fields-for-atom-images-copyright-source-photographer-suppliersreference-so-rcs-can-better)