### PR TITLE
Content Atom: bump version

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
-  lazy val contentAtomVersion = "2.4.63"
+  lazy val contentAtomVersion = "2.4.65"
   lazy val scroogeVersion     = "4.18.0"
   lazy val akkaVersion        = "2.4.8"
   lazy val playVersion        = "2.5.3"


### PR DESCRIPTION
We want to add a new audio atom. 
Need to incorporate new thrift models from latest version of content-atom 