### PR TITLE
Bump content-atom version for emailsignup atom support

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
-  lazy val contentAtomVersion = "3.1.2"
+  lazy val contentAtomVersion = "3.2.0"
   lazy val scroogeVersion     = "19.3.0"
   lazy val akkaVersion        = "2.4.8"
   lazy val playVersion        = "2.5.3"


### PR DESCRIPTION
In https://github.com/guardian/content-atom/pull/133 we defined an emailsignup atom,  now that the latest version of [content-atom-model-thrift](https://search.maven.org/artifact/com.gu/content-atom-model-thrift) has been published, I'd like to use the latest version to recognise this new atom type.

The aim of this work is to define an atom type for email sign up, the motivations for this are outlined [here](https://github.com/guardian/content-atom/pull/133).
