### PR TITLE
Fix a couple of typos

### DIFF
--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomPublisher.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomPublisher.scala
@@ -12,13 +12,13 @@ class KinesisAtomPublisher (val streamName: String, val kinesis: AmazonKinesisCl
     with LazyLogging
 {
 
-  logger.info(s"KinsisAtomPublisher started with streamName $streamName")
+  logger.info(s"KinesisAtomPublisher started with streamName $streamName")
 
-  def makeParititionKey(event: ContentAtomEvent): String = event.atom.atomType.name
+  def makePartitionKey(event: ContentAtomEvent): String = event.atom.atomType.name
 
   def publishAtomEvent(event: ContentAtomEvent): Try[Unit] = Try {
       val data = serializeEvent(event)
-      kinesis.putRecord(streamName, data, makeParititionKey(event))
+      kinesis.putRecord(streamName, data, makePartitionKey(event))
     }
 }
 

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -11,13 +11,13 @@ class KinesisAtomReindexer(
     extends AtomReindexer
     with ThriftSerializer[ContentAtomEvent] {
 
-  def makeParititionKey(event: ContentAtomEvent): String = event.atom.atomType.name
+  def makePartitionKey(event: ContentAtomEvent): String = event.atom.atomType.name
 
   def startReindexJob(atomEventsToReindex: Iterator[ContentAtomEvent], expectedSize: Int) =
     new AtomReindexJob(atomEventsToReindex, expectedSize) {
       def execute(implicit ec: ExecutionContext) = Future {
         atomEventsToReindex foreach { atomEvent =>
-          kinesis.putRecord(streamName, serializeEvent(atomEvent), makeParititionKey(atomEvent))
+          kinesis.putRecord(streamName, serializeEvent(atomEvent), makePartitionKey(atomEvent))
           _completedCount += 1
         }
         _isComplete = true


### PR DESCRIPTION
## What does this change?

Fixes a couple of typos. I noticed the 'Kinsis' typo in a `media-atom-maker` log and then noticed the second when I found the file.
