### PR TITLE
Play 2.6 upgrade

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -12,6 +12,6 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play"    % "1.5.0"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
   "org.mockito"            %  "mockito-core"          % mockitoVersion % "test",
-  "com.typesafe.play"      %% "play-test"             % "2.6.0" % Test,
+  "com.typesafe.play"      %% "play-test"             % "2.6.0" % "test",
   guice
 )

--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -11,5 +11,7 @@ libraryDependencies ++= Seq(
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
   "org.scalatestplus.play" %% "scalatestplus-play"    % "1.5.0"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
-  "org.mockito"            %  "mockito-core"          % mockitoVersion % "test"
+  "org.mockito"            %  "mockito-core"          % mockitoVersion % "test",
+  "com.typesafe.play"      %% "play-test"             % "2.6.0" % Test,
+  guice
 )

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/AtomAPIActions.scala
@@ -11,7 +11,7 @@ import play.api.mvc._
 
 import scala.util.{Failure, Success}
 
-trait AtomAPIActions extends Controller {
+trait AtomAPIActions extends BaseController {
 
   val livePublisher: LiveAtomPublisher
   val previewPublisher: PreviewAtomPublisher

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -1,7 +1,6 @@
 package com.gu.atom.play.test
 
 import java.util.Date
-
 import com.gu.atom.TestData._
 import com.gu.atom.play._
 import com.gu.contentatom.thrift._
@@ -9,7 +8,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.Inside
-import play.api.mvc.Controller
+import play.api.mvc.{AbstractController, BaseController}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
@@ -23,7 +22,7 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
     m
   }
 
-  def apiActions(implicit conf: AtomTestConf) = new Controller with AtomAPIActions {
+  def apiActions(implicit conf: AtomTestConf) = new AbstractController(stubControllerComponents()) with AtomAPIActions {
     val livePublisher = conf.livePublisher
     val previewPublisher = conf.previewPublisher
     val previewDataStore = conf.previewDataStore

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -14,9 +14,9 @@ scalaVersion := "2.11.11"
 
 // for testing dynamodb access
 dynamoDBLocalDownloadDir := file(".dynamodb-local")
-startDynamoDBLocal <<= startDynamoDBLocal.dependsOn(compile in Test)
-test in Test <<= (test in Test).dependsOn(startDynamoDBLocal)
-testOptions in Test <+= dynamoDBLocalTestCleanup
+startDynamoDBLocal := startDynamoDBLocal.dependsOn(compile in Test).value
+test in Test := (test in Test).dependsOn(startDynamoDBLocal)
+testOptions in Test += dynamoDBLocalTestCleanup.value
 
 dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.10.0"
 dependencyOverrides += "com.twitter" %% "scrooge-core" % scroogeVersion

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -2,7 +2,7 @@ package com.gu.atom.data
 
 import java.util
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.document._
 import com.amazonaws.services.dynamodbv2.model.{ConditionalCheckFailedException, DeleteItemResult}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
@@ -23,7 +23,7 @@ object AtomSerializer {
 }
 
 abstract class DynamoDataStore
-  (dynamo: AmazonDynamoDBClient, tableName: String)
+  (dynamo: AmazonDynamoDB, tableName: String)
     extends AtomDataStore {
 
   private val dynamoDB = new DynamoDB(dynamo)
@@ -160,7 +160,7 @@ abstract class DynamoDataStore
 }
 
 class PreviewDynamoDataStore
-(dynamo: AmazonDynamoDBClient, tableName: String)
+(dynamo: AmazonDynamoDB, tableName: String)
   extends DynamoDataStore(dynamo, tableName)
   with PreviewDataStore {
 
@@ -171,7 +171,7 @@ class PreviewDynamoDataStore
 }
 
 class PublishedDynamoDataStore
-(dynamo: AmazonDynamoDBClient, tableName: String)
+(dynamo: AmazonDynamoDB, tableName: String)
   extends DynamoDataStore(dynamo, tableName)
   with PublishedDataStore {
 

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomPublisher.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomPublisher.scala
@@ -1,12 +1,12 @@
 package com.gu.atom.publish
 
-import com.amazonaws.services.kinesis.AmazonKinesisClient
+import com.amazonaws.services.kinesis.AmazonKinesis
 import com.gu.contentatom.thrift.ContentAtomEvent
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try
 
-class KinesisAtomPublisher (val streamName: String, val kinesis: AmazonKinesisClient)
+class KinesisAtomPublisher (val streamName: String, val kinesis: AmazonKinesis)
     extends AtomPublisher
     with ThriftSerializer[ContentAtomEvent]
     with LazyLogging
@@ -23,9 +23,9 @@ class KinesisAtomPublisher (val streamName: String, val kinesis: AmazonKinesisCl
 }
 
 class PreviewKinesisAtomPublisher(override val streamName: String,
-                                  override val kinesis: AmazonKinesisClient)
+                                  override val kinesis: AmazonKinesis)
   extends KinesisAtomPublisher(streamName, kinesis) with PreviewAtomPublisher
 
 class LiveKinesisAtomPublisher(override val streamName: String,
-                                  override val kinesis: AmazonKinesisClient)
+                                  override val kinesis: AmazonKinesis)
   extends KinesisAtomPublisher(streamName, kinesis) with LiveAtomPublisher

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/publish/KinesisAtomReindexer.scala
@@ -1,13 +1,13 @@
 package com.gu.atom.publish
 
-import com.amazonaws.services.kinesis.AmazonKinesisClient
+import com.amazonaws.services.kinesis.AmazonKinesis
 import com.gu.contentatom.thrift.ContentAtomEvent
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class KinesisAtomReindexer(
   streamName: String,
-  kinesis: AmazonKinesisClient)
+  kinesis: AmazonKinesis)
     extends AtomReindexer
     with ThriftSerializer[ContentAtomEvent] {
 
@@ -27,11 +27,11 @@ class KinesisAtomReindexer(
 }
 
 class PreviewKinesisAtomReindexer( val streamName: String,
-                                   val kinesis: AmazonKinesisClient)
+                                   val kinesis: AmazonKinesis)
   extends KinesisAtomReindexer(streamName, kinesis) with PreviewAtomReindexer
 
 class PublishedKinesisAtomReindexer( val streamName: String,
-                                     val kinesis: AmazonKinesisClient)
+                                     val kinesis: AmazonKinesis)
   extends KinesisAtomReindexer(streamName, kinesis) with PublishedAtomReindexer
 
  

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -3,9 +3,9 @@ import sbt._
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
   lazy val contentAtomVersion = "3.2.0"
-  lazy val scroogeVersion     = "19.3.0"
-  lazy val akkaVersion        = "2.4.8"
-  lazy val playVersion        = "2.5.3"
+  lazy val scroogeVersion     = "19.9.0"
+  lazy val akkaVersion        = "2.5.3"
+  lazy val playVersion        = "2.6.0"
   lazy val mockitoVersion     = "2.0.97-beta"
 
   lazy val scanamoDeps = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 


### PR DESCRIPTION
## What does this change?

Attempts to make minimum changes necessary to upgrade library to use Play 2.6 and remove warnings.  

This will allows us to upgrade these projects to Play 2.6:

* [atom-workshop](https://github.com/guardian/atom-workshop)
* [review-maker](https://github.com/guardian/review-maker)
* [explain-maker](https://github.com/guardian/explain-maker)
* [media-atom-maker](https://github.com/guardian/media-atom-maker)

Also switches from using for example `AmazonDynamoDBClient` implementation to `AmazonDynamoDB` interface.  This will make it easier for library users to avoid deprecation warnings for using `region.createClient` instead of `AmazonDynamoDBClientBuilder`