### PR TITLE
crossbuild to scala 2.12

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -9,7 +9,7 @@ name := "atom-manager-play"
 libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
-  "org.scalatestplus.play" %% "scalatestplus-play"    % "1.5.0"   % "test",
+  "org.scalatestplus.play" %% "scalatestplus-play"    % "3.1.2"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
   "org.mockito"            %  "mockito-core"          % mockitoVersion % "test",
   "com.typesafe.play"      %% "play-test"             % "2.6.0" % "test",

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -1,16 +1,6 @@
 import BuildVars._
-import com.typesafe.sbt.SbtPgp.autoImportImpl._
-import sbtrelease._
-
-import ReleaseStateTransformations._
-
-
-Sonatype.sonatypeSettings
 
 name := "atom-publisher-lib"
-
-organization := "com.gu"
-scalaVersion := "2.11.11"
 
 // for testing dynamodb access
 dynamoDBLocalDownloadDir := file(".dynamodb-local")
@@ -28,11 +18,11 @@ libraryDependencies ++= Seq(
   "com.gu"                     %% "fezziwig"             % "1.1",
   "com.gu"                     %% "content-atom-model"   % contentAtomVersion,
   "com.amazonaws"              %  "aws-java-sdk-kinesis" % awsVersion,
-  "com.typesafe.scala-logging" %% "scala-logging"        % "3.4.0",
+  "com.typesafe.scala-logging" %% "scala-logging"        % "3.9.5",
   "com.twitter"                %% "scrooge-serializer"   % scroogeVersion,
   "com.twitter"                %% "scrooge-core"         % scroogeVersion,
   "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
   "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
-  "org.scalatest"              %% "scalatest"            % "2.2.6" % "test",
+  "org.scalatest"              %% "scalatest"            % "3.0.0" % "test",
   "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test"
 ) ++  scanamoDeps

--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,15 @@ import sbtrelease._
 
 import ReleaseStateTransformations._
 
+val scala2_11 = "2.11.12"
+val scala2_12 = "2.12.16"
+
 name := "atom-maker-lib"
 
 lazy val baseSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.11.12",
+  scalaVersion := scala2_11,
+  crossScalaVersions := Seq(scala2_11, scala2_12),
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/atom-maker"),
     "scm:git:git@github.com:guardian/atom-maker.git"))
@@ -37,6 +41,7 @@ lazy val atomLibraries = (project in file("."))
   publishArtifact := false,
   publish := {},
   publishLocal := {},
+  releaseCrossBuild := true,
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,
@@ -45,7 +50,7 @@ lazy val atomLibraries = (project in file("."))
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    ReleaseStep(action = Command.process("publishSigned", _)),
+    ReleaseStep(action = Command.process("+publishSigned", _)),
     setNextVersion,
     commitNextVersion,
     ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import com.typesafe.sbt.SbtPgp.autoImportImpl._
 import sbtrelease._
 
 import ReleaseStateTransformations._

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -9,7 +9,6 @@ object BuildVars {
   lazy val mockitoVersion     = "2.0.97-beta"
 
   lazy val scanamoDeps = Seq(
-    "org.scanamo" %% "scanamo" % "1.0.0-M9",
-    "com.gu" %% "scanamo-scrooge" % "0.2.1"
+    "org.scanamo" %% "scanamo" % "1.0.0-M9"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 // for creating test cases that use a local dynamodb
-
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 


### PR DESCRIPTION
2.13 is a little away - libraries like scanamo, fezziwig, circe and akka-actor need upgrading or removing

## What does this change?

Adds cross-building for 2.11+2.12 - being able to do this before the play 2.7 upgrade makes slightly nicer, smaller commits (from experience in MAM)