### PR TITLE
Bump Scala to 2.12

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -6,12 +6,15 @@ lazy val AwsSdkVersion = "1.11.8"
 
 name := "atom-manager-play"
 
+// Necessary because of a conflict between catz, imported by scanamo 1.0.0M9, and scanamo-scrooge
+dependencyOverrides += "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4"
+
 libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
-  "org.scalatestplus.play" %% "scalatestplus-play"    % "1.5.0"   % "test",
+  "org.scalatestplus.play" %% "scalatestplus-play"    % "5.1.0"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
-  "org.mockito"            %  "mockito-core"          % mockitoVersion % "test",
+  "org.scalatestplus" %% "mockito-4-5" % "3.2.12.0" % "test",
   "com.typesafe.play"      %% "play-test"             % "2.6.0" % "test",
   guice
 )

--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -12,9 +12,15 @@ dependencyOverrides += "org.scala-lang.modules" %% "scala-collection-compat" % "
 libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
-  "org.scalatestplus.play" %% "scalatestplus-play"    % "5.1.0"   % "test",
+  "org.scalatestplus.play" %% "scalatestplus-play"    % "3.1.3"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
-  "org.scalatestplus" %% "mockito-4-5" % "3.2.12.0" % "test",
+  "org.scalatestplus"      %% "mockito-3-3"           % "3.1.2.0" % "test",
   "com.typesafe.play"      %% "play-test"             % "2.6.0" % "test",
   guice
+)
+
+
+dependencyOverrides ++= Seq(
+  "org.mockito"                %  "mockito-core"         % "2.7.22",
+  "org.scalatest"              %% "scalatest"            % "3.0.8"
 )

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -8,7 +8,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.Inside
-import play.api.mvc.{AbstractController, BaseController}
+import play.api.mvc.{AbstractController}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -5,16 +5,15 @@ import com.gu.atom.data._
 import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule, GuiceableModuleConversions}
 import play.api.inject.{Binding, bind}
 
-import scala.collection.mutable.{Map => MMap}
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 
-trait AtomSuite extends PlaySpec with GuiceableModuleConversions {
+trait AtomSuite extends PlaySpec with MockitoSugar with GuiceableModuleConversions {
 
   def dataStore = mock[AtomDataStore]
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -34,6 +34,7 @@ libraryDependencies ++= Seq(
   "com.twitter"                %% "scrooge-core"         % scroogeVersion,
   "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
   "org.scalatest"              %% "scalatest"            % "3.2.12" % "test",
-  "org.scalatestplus" %% "mockito-4-5" % "3.2.12.0" % "test",
+  "org.scalatestplus"          %% "mockito-3-3"          % "3.1.2.0" % "test",
   "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test"
 ) ++  scanamoDeps
+

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -1,8 +1,6 @@
 import BuildVars._
-import com.typesafe.sbt.SbtPgp.autoImportImpl._
 import sbtrelease._
-
-import ReleaseStateTransformations._
+import ReleaseTransformations._
 
 
 Sonatype.sonatypeSettings
@@ -10,7 +8,7 @@ Sonatype.sonatypeSettings
 name := "atom-publisher-lib"
 
 organization := "com.gu"
-scalaVersion := "2.11.11"
+scalaVersion := "2.12.16"
 
 // for testing dynamodb access
 dynamoDBLocalDownloadDir := file(".dynamodb-local")
@@ -21,6 +19,9 @@ testOptions in Test += dynamoDBLocalTestCleanup.value
 dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.10.0"
 dependencyOverrides += "com.twitter" %% "scrooge-core" % scroogeVersion
 dependencyOverrides += "com.twitter" %% "scrooge-serializer" % scroogeVersion
+// Necessary because of a conflict between catz, imported by scanamo 1.0.0M9, and scanamo-scrooge
+dependencyOverrides += "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4"
+
 
 libraryDependencies ++= Seq(
   "org.typelevel"              %% "cats-core"            % "1.5.0",
@@ -28,11 +29,11 @@ libraryDependencies ++= Seq(
   "com.gu"                     %% "fezziwig"             % "1.1",
   "com.gu"                     %% "content-atom-model"   % contentAtomVersion,
   "com.amazonaws"              %  "aws-java-sdk-kinesis" % awsVersion,
-  "com.typesafe.scala-logging" %% "scala-logging"        % "3.4.0",
+  "com.typesafe.scala-logging" %% "scala-logging"        % "3.5.0",
   "com.twitter"                %% "scrooge-serializer"   % scroogeVersion,
   "com.twitter"                %% "scrooge-core"         % scroogeVersion,
   "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
-  "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
-  "org.scalatest"              %% "scalatest"            % "2.2.6" % "test",
+  "org.scalatest"              %% "scalatest"            % "3.2.12" % "test",
+  "org.scalatestplus" %% "mockito-4-5" % "3.2.12.0" % "test",
   "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test"
 ) ++  scanamoDeps

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -5,10 +5,12 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import com.gu.atom.TestData._
 import com.gu.atom.util.{AtomImplicitsGeneral, JsonSupport}
 import com.gu.contentatom.thrift.Atom
-import org.scalatest.{BeforeAndAfterAll, Matchers, OptionValues, fixture}
+import org.scalatest.funspec.{FixtureAnyFunSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, OptionValues}
 
 class DynamoDataStoreSpec
-    extends fixture.FunSpec
+    extends FixtureAnyFunSpec
     with Matchers
     with OptionValues
     with BeforeAndAfterAll

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
@@ -1,19 +1,19 @@
 package com.gu.atom.publish.test
 
 import java.nio.ByteBuffer
-
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.gu.atom.TestData._
 import com.gu.atom.publish.KinesisAtomPublisher
 import org.mockito.ArgumentMatchers.{eq => argEq, _}
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.{Failure, Success}
 
 class KinesisAtomPublisherSpec
-    extends FunSpec
+    extends AnyFunSpec
     with Matchers
     with MockitoSugar {
 

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -4,16 +4,17 @@ import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.gu.atom.TestData
 import com.gu.atom.publish.{PreviewKinesisAtomReindexer, PublishedKinesisAtomReindexer}
 import org.mockito.ArgumentMatchers.{eq => meq, _}
-import org.mockito.Mockito._
+import org.mockito.Mockito.{times, verify}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class KinesisAtomReindexerSpec
-    extends FunSpecLike
+    extends AnyFunSpecLike
     with Matchers
     with ScalaFutures
     with MockitoSugar {

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,11 @@
-import com.typesafe.sbt.SbtPgp.autoImportImpl._
-import sbtrelease._
-
-import ReleaseStateTransformations._
+import ReleaseTransformations._
+import xerial.sbt.Sonatype._
 
 name := "atom-maker-lib"
 
 lazy val baseSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.11.12",
+  scalaVersion := "2.12.16",
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/atom-maker"),
     "scm:git:git@github.com:guardian/atom-maker.git"))

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -4,7 +4,7 @@ object BuildVars {
   lazy val awsVersion         = "1.11.8"
   lazy val contentAtomVersion = "3.2.0"
   lazy val scroogeVersion     = "22.4.0"
-  lazy val akkaVersion        = "2.6.3"
+  lazy val akkaVersion        = "2.5.3"
   lazy val playVersion        = "2.6.0"
 
   lazy val scanamoDeps = Seq(

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -3,13 +3,12 @@ import sbt._
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
   lazy val contentAtomVersion = "3.2.0"
-  lazy val scroogeVersion     = "19.9.0"
-  lazy val akkaVersion        = "2.5.3"
+  lazy val scroogeVersion     = "22.4.0"
+  lazy val akkaVersion        = "2.6.3"
   lazy val playVersion        = "2.6.0"
-  lazy val mockitoVersion     = "2.0.97-beta"
 
   lazy val scanamoDeps = Seq(
     "org.scanamo" %% "scanamo" % "1.0.0-M9",
-    "com.gu" %% "scanamo-scrooge" % "0.2.1"
+    "com.gu" %% "scanamo-scrooge" % "0.2.2-SNAPSHOT"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,16 +2,14 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
 
 // for creating test cases that use a local dynamodb
 
-addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.2")


### PR DESCRIPTION
_NB: this is dependent on [an update to scanamo-scrooge](https://github.com/guardian/scanamo-scrooge/pull/15), which at time of writing is not yet released._

## What does this change?

Bumps Scala to 2.12, and sbt to 1.7.1.

## How to test

The project should compile, and the tests should pass.