### PR TITLE
Upgrade remaining play dependency versions to 2.7 and upgrade repo to scala 2.12

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -12,6 +12,6 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play"    % "4.0.0"   % "test",
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
   "org.mockito"            %  "mockito-core"          % mockitoVersion % "test",
-  "com.typesafe.play"      %% "play-test"             % "2.6.0" % "test",
+  "com.typesafe.play"      %% "play-test"             % "2.7.9" % "test",
   guice
 )

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -21,8 +21,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging"        % "3.9.5",
   "com.twitter"                %% "scrooge-serializer"   % scroogeVersion,
   "com.twitter"                %% "scrooge-core"         % scroogeVersion,
-  "com.typesafe.akka"          %% "akka-actor"           % akkaVersion,
   "org.mockito"                %  "mockito-core"         % mockitoVersion % "test",
-  "org.scalatest"              %% "scalatest"            % "3.0.0" % "test",
-  "com.typesafe.akka"          %% "akka-testkit"         % akkaVersion % "test"
+  "org.scalatest"              %% "scalatest"            % "3.0.0" % "test"
 ) ++  scanamoDeps

--- a/build.sbt
+++ b/build.sbt
@@ -9,11 +9,12 @@ name := "atom-maker-lib"
 
 lazy val baseSettings = Seq(
   organization := "com.gu",
-  scalaVersion := scala2_11,
+  scalaVersion := scala2_12,
   crossScalaVersions := Seq(scala2_11, scala2_12),
   licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/atom-maker"),
-    "scm:git:git@github.com:guardian/atom-maker.git"))
+    "scm:git:git@github.com:guardian/atom-maker.git")),
+  scalacOptions := Seq("-deprecation", "-feature")
 )
 
 lazy val atomPublisher = (project in file("./atom-publisher-lib"))

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -5,7 +5,7 @@ object BuildVars {
   lazy val contentAtomVersion = "3.2.0"
   lazy val scroogeVersion     = "19.9.0"
   lazy val akkaVersion        = "2.5.3"
-  lazy val playVersion        = "2.6.0"
+  lazy val playVersion        = "2.7.9"
   lazy val mockitoVersion     = "2.0.97-beta"
 
   lazy val scanamoDeps = Seq(

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -4,7 +4,6 @@ object BuildVars {
   lazy val awsVersion         = "1.11.8"
   lazy val contentAtomVersion = "3.2.0"
   lazy val scroogeVersion     = "19.9.0"
-  lazy val akkaVersion        = "2.5.3"
   lazy val playVersion        = "2.7.9"
   lazy val mockitoVersion     = "2.0.97-beta"
 


### PR DESCRIPTION
## What does this change?

Tests are failing - the play upgrade causes a abstractmethoderror when running tests.

This comment https://github.com/hmrc/play-whitelist-filter/blob/master/build.sbt#L45-L47
leads to this thread https://github.com/scala/scala-parser-combinators/issues/197
which mentions that Scala 2.12 is okay. This issue seems to only affect tests, (this issue suggests run tests in forked mode) and I've had success with running the compiled artifact, so I've set the "main" Scala version to 2.12 to run the tests, and continue providing the cross-built release for 2.11 (which we should consider deprecated and remove soon).

## How to test

`sbt test` passes, play does not appear in `sbt evicted`
