### PR TITLE
move ci to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: 8
     - name: Build and Test
       run: sbt clean compile test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+    - name: Setup JDK
+      uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
+      with:
+        distribution: temurin
+        java-version: 8
+    - name: Build and Test
+      run: sbt clean compile test


### PR DESCRIPTION
## What does this change?

The previous teamcity build was using Teamcity's sbt runner... which exits with 0 even if tests fail 😱 
We could have just replaced it with the script runner running the sbt build, but since it's such a simple CI build (`sbt clean compile test`), and the department recommends moving to GHA, we might as well do that now.

## How to test

Does the CI run on this branch? If you intentionally break a test, does the CI runner report that failure? 

(The GHA build for this PR is currently **failing** --- which correctly reflects the current test failures. Note that the Teamcity build has passed despite the test failures.)

## How can we measure success?

Visibility on test failures in PRs.

## Have we considered potential risks?

