### PR TITLE
chore(deps): bump Akka from 2.5.3 -> 2.5.16

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -4,7 +4,7 @@ object BuildVars {
   lazy val awsVersion         = "1.11.8"
   lazy val contentAtomVersion = "3.2.0"
   lazy val scroogeVersion     = "19.9.0"
-  lazy val akkaVersion        = "2.5.3"
+  lazy val akkaVersion        = "2.5.16"
   lazy val playVersion        = "2.6.0"
   lazy val mockitoVersion     = "2.0.97-beta"
 


### PR DESCRIPTION
## What does this change?

This change bumps the version of Akka used in this project to avoid https://security.snyk.io/vuln/SNYK-JAVA-COMTYPESAFEAKKA-451678