### PR TITLE
temporarily run tests in forked jvm to avoid classpath issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,9 @@ lazy val baseSettings = Seq(
   licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/atom-maker"),
     "scm:git:git@github.com:guardian/atom-maker.git")),
-  scalacOptions := Seq("-deprecation", "-feature")
+  scalacOptions := Seq("-deprecation", "-feature"),
+  // FIXME remove when 2.11 build/release is discontinued
+  fork in Test := true
 )
 
 lazy val atomPublisher = (project in file("./atom-publisher-lib"))


### PR DESCRIPTION
## What does this change?

#74 did not solve all of the problems :( 

scala-parser-combinators 1.1.2 and scala 2.11 do not get along well in tests (because scala 2.11 has
a different version of scala-parser-combinators on its classpath). forking the process when running
the tests means that the tests can have their own, separate classpath which will not have version
conflicts from this lib. Scalas >= 2.12 do not have scala-parser-combinators on their classpath,
so this problem will go away when we drop Scala 2.11 (hopefully soon)

## How to test

`sbt +test` passes :white_check_mark:

## How can we measure success?

the release can finally proceed
