### PR TITLE
Upgrade to sbt v1.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 public/dist
 .ensime*
 .DS_Store
+.bsp/

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -4,9 +4,9 @@ name := "atom-publisher-lib"
 
 // for testing dynamodb access
 dynamoDBLocalDownloadDir := file(".dynamodb-local")
-startDynamoDBLocal := startDynamoDBLocal.dependsOn(compile in Test).value
-test in Test := (test in Test).dependsOn(startDynamoDBLocal)
-testOptions in Test += dynamoDBLocalTestCleanup.value
+startDynamoDBLocal := startDynamoDBLocal.dependsOn(Test / compile).value
+Test / test := (Test / test).dependsOn(startDynamoDBLocal).value
+Test / testOptions += dynamoDBLocalTestCleanup.value
 
 dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.10.0"
 dependencyOverrides += "com.twitter" %% "scrooge-core" % scroogeVersion

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val baseSettings = Seq(
     "scm:git:git@github.com:guardian/atom-maker.git")),
   scalacOptions := Seq("-deprecation", "-feature"),
   // FIXME remove when 2.11 build/release is discontinued
-  fork in Test := true
+  Test / fork := true
 )
 
 lazy val atomPublisher = (project in file("./atom-publisher-lib"))
@@ -25,7 +25,7 @@ lazy val atomPublisher = (project in file("./atom-publisher-lib"))
     organization := "com.gu",
     name := "atom-publisher-lib"
   )
-  .settings(publishArtifact in Test := true)
+  .settings(Test / publishArtifact := true)
 
 
 lazy val atomManagerPlay = (project in file("./atom-manager-play-lib"))
@@ -34,7 +34,7 @@ lazy val atomManagerPlay = (project in file("./atom-manager-play-lib"))
     organization := "com.gu",
     name := "atom-manager-play-lib"
   )
-  .settings(publishArtifact in Test := true)
+  .settings(Test / publishArtifact := true)
   .dependsOn(atomPublisher % "test->test;compile->compile")
 
 lazy val atomLibraries = (project in file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=0.13.16
+sbt.version=1.8.0
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,15 +4,21 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
-
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15")
 
 // for creating test cases that use a local dynamodb
-addSbtPlugin("com.localytics" % "sbt-dynamodb" % "1.5.3")
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.3")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+/*
+   scala-xml has been updated to 2.x in sbt, but not in other sbt plugins like sbt-native-packager
+   See: https://github.com/scala/bug/issues/12632
+   This is effectively overrides the safeguards (early-semver) put in place by the library authors ensuring binary compatibility.
+   We consider this a safe operation because when set under `projects/` (ie *not* in `build.sbt` itself) it only affects the
+   compilation of build.sbt, not of the application build itself.
+   Once the build has succeeded, there is no further risk (ie of a runtime exception due to clashing versions of `scala-xml`).
+ */
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,6 +1,6 @@
 sonatypeProfileName := "com.gu"
 
-pomExtra in ThisBuild := (
+ThisBuild / pomExtra := (
   <url>https://github.com/guardian/atom-maker</url>
     <developers>
       <developer>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.2-SNAPSHOT"
+ThisBuild / version := "1.3.2-SNAPSHOT"


### PR DESCRIPTION
Some motivations for this upgrade:

* sbt prior to v1.4.5 has trouble on Apple Silicon M1 laptops (which most Guardian devs are now using!) - https://github.com/sbt/sbt/issues/6162#issuecomment-774519485
* [recommendations for the Log4j vulnerability](https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo/edit?usp=sharing) suggest using at least sbt 1.5.7

Main changes happening in this PR to upgrade to sbt v1.8.0:

* Updating to [sbt slash-syntax](https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+to+slash+syntax)
* Updated plugin versions to be compatible with this version of sbt
