### PR TITLE
Support Java 11 (update Mockito to allow tests to be run under Java 11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8', '11']
+    name: Run Tests (Java ${{ matrix.java }})
     steps:
     - name: Checkout
       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
@@ -15,6 +19,6 @@ jobs:
       uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
       with:
         distribution: corretto
-        java-version: 8
+        java-version: ${{ matrix.java }}
     - name: Build and Test
       run: sbt clean compile test

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -5,12 +5,11 @@ import com.gu.atom.data._
 import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar.mock
+import org.scalatest.mockito.MockitoSugar.mock
 import org.scalatestplus.play.PlaySpec
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule, GuiceableModuleConversions}
 import play.api.inject.{Binding, bind}
 
-import scala.collection.mutable.{Map => MMap}
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -22,6 +22,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging"         % "3.9.5",
   "com.twitter"                %% "scrooge-serializer"    % scroogeVersion,
   "com.twitter"                %% "scrooge-core"          % scroogeVersion,
-  "org.mockito"                %  "mockito-core"          % mockitoVersion % "test",
-  "org.scalatest"              %% "scalatest"             % "3.0.0" % "test"
+  "org.mockito"                %  "mockito-core"          % mockitoVersion % Test,
+  "org.scalatest"              %% "scalatest"             % "3.0.0" % Test
 )

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
@@ -1,13 +1,12 @@
 package com.gu.atom.publish.test
 
 import java.nio.ByteBuffer
-
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.gu.atom.TestData._
 import com.gu.atom.publish.KinesisAtomPublisher
 import org.mockito.ArgumentMatchers.{eq => argEq, _}
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 
 import scala.util.{Failure, Success}
@@ -31,10 +30,10 @@ class KinesisAtomPublisherSpec
     it("should report exception") {
       val kinesis = mock[AmazonKinesisClient]
       when(kinesis.putRecord(argEq(streamName), any(classOf[ByteBuffer]), anyString()))
-        .thenThrow(classOf[Exception])
+        .thenThrow(classOf[RuntimeException])
       val publisher = new KinesisAtomPublisher(streamName, kinesis)
       val res = publisher.publishAtomEvent(testAtomEvent())
-      res should matchPattern { case Failure(e: Exception) => }
+      res should matchPattern { case Failure(e: RuntimeException) => }
     }
 
   }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -6,7 +6,7 @@ import com.gu.atom.publish.{PreviewKinesisAtomReindexer, PublishedKinesisAtomRei
 import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpecLike, Matchers}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -5,5 +5,5 @@ object BuildVars {
   lazy val contentAtomVersion = "3.2.0"
   lazy val scroogeVersion     = "19.9.0"
   lazy val playVersion        = "2.8.8"
-  lazy val mockitoVersion     = "2.0.97-beta"
+  lazy val mockitoVersion     = "4.8.0"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15")
 
@@ -16,12 +16,11 @@ addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.3")
 addDependencyTreePlugin
 
 /*
-   Because scala-xml has not be updated to 2.x in sbt yet but has in sbt-native-packager
+   scala-xml has been updated to 2.x in sbt, but not in other sbt plugins like sbt-native-packager
    See: https://github.com/scala/bug/issues/12632
-
-   This effectively overrides the safeguards (early-semver) put in place by the library authors ensuring binary compatibility.
-   We consider this a safe operation because it only affects the compilation of build.sbt, not of the application build itself
+   This is effectively overrides the safeguards (early-semver) put in place by the library authors ensuring binary compatibility.
+   We consider this a safe operation because when set under `projects/` (ie *not* in `build.sbt` itself) it only affects the
+   compilation of build.sbt, not of the application build itself.
+   Once the build has succeeded, there is no further risk (ie of a runtime exception due to clashing versions of `scala-xml`).
  */
-libraryDependencySchemes ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,6 +1,6 @@
 sonatypeProfileName := "com.gu"
 
-pomExtra in ThisBuild := (
+ThisBuild / pomExtra := (
   <url>https://github.com/guardian/atom-maker</url>
     <developers>
       <developer>


### PR DESCRIPTION
DevX has [recommended](https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit) that teams stop using Java 8, so it's good to get this project capable of running tests under Java 11!

I've updated the CI to ensure that for now, both Java 8 and Java 11 successfully pass tests:

![image](https://user-images.githubusercontent.com/52038/206258911-3267ed87-13e1-4da1-aa8e-a119957eb949.png)


#### Mockito update

The only blocker is the old version of Mockito, which would throw this error when running tests under Java 11:

```
java.lang.UnsupportedOperationException: Cannot define class using reflection: Could not find sun.misc.Unsafe
```

It looks like Java 11 compatibility was added to Mockito with a bytebuddy update sometime around 2019 (see https://github.com/mockito/mockito/issues/1483 & https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md) so just upgrading to the latest version fixes the issue.

There's also a couple of changes to mocking-exceptions in the tests, as the later version of Mockito is more strict - you can't say `thenThrow(classOf[Exception])` if the exception is a checked-exception, and method you're mocking doesn't
actually throw that exception! So instead we just say `thenThrow(classOf[RuntimeException])`, which is something any method can do at anytime, without having to declare it in its signature.
