### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For the atoms to appear in capi you will also have to make necessary changes to 
 
 An example of a project that uses these libraries to manage atoms can be found [here](https://github.com/guardian/media-atom-maker).
 
-## Atom-publisher-lib ![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/atom-publisher-lib_2.11/badge.svg)
+## Atom-publisher-lib [![atom-publisher-lib Scala version support](https://index.scala-lang.org/guardian/atom-maker/atom-publisher-lib/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/atom-maker/atom-publisher-lib)
 - Provides that traits you an inject in your application
 
 ### PublishedStore and PreviewDataStore


### PR DESCRIPTION
This Scaladex badge summarises which versions of Scala are supported by `atom-publisher-lib` (and what the latest `atom-publisher-lib` version is for each of those Scala versions), so it provides a bit more information than a Maven badge - can be useful to newcomers to the project!

[![atom-publisher-lib Scala version support](https://index.scala-lang.org/guardian/atom-maker/atom-publisher-lib/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/atom-maker/atom-publisher-lib)

Note that the old Maven badge was pointing at the Scala 2.11 version of `atom-publisher-lib`, so was out-of-date! It shows showing version 1.3.1, rather than 1.3.2: ![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/atom-publisher-lib_2.11/badge.svg)

More details on the badge format: scalacenter/scaladex#660
