### PR TITLE
Cross compile for scala v2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         distribution: corretto
         java-version: ${{ matrix.java }}
     - name: Build and Test
-      run: sbt clean compile test
+      run: sbt +clean +compile +test

--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -5,9 +5,9 @@ name := "atom-manager-play"
 libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
-  "org.scalatestplus.play" %% "scalatestplus-play"    % "4.0.0"   % "test",
+  "org.scalatestplus.play" %% "scalatestplus-play"    % "5.1.0" % Test,
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
-  "org.mockito"            %  "mockito-core"          % mockitoVersion % "test",
-  "com.typesafe.play"      %% "play-test"             % playVersion % "test",
+  "org.mockito"            %  "mockito-core"          % mockitoVersion % Test,
+  "com.typesafe.play"      %% "play-test"             % playVersion % Test,
   guice
 )

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
@@ -34,17 +34,17 @@ class ReindexActor(reindexer: AtomReindexer) extends Actor {
       job.execute.onComplete {
         case _ => context.become(idleState(Some(job)), true)
       }
-      sender ! RSuccess
+      sender() ! RSuccess
 
     case GetStatus =>
-      sender ! lastJob.map(statusReply)
+      sender() ! lastJob.map(statusReply)
   }
 
   def inProgressState(job: AtomReindexJob): Receive = {
     case CreateJob(_, _) =>
-      sender ! RFailure("in progress")
+      sender() ! RFailure("in progress")
     case GetStatus =>
-      sender ! Some(statusReply(job))
+      sender() ! Some(statusReply(job))
   }
 
   /* start off in idle state with no record of a previous job */

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -73,7 +73,7 @@ trait AtomSuite extends PlaySpec with GuiceableModuleConversions {
     publishedDataStore: PublishedDataStore = initialPublishedDataStore,
     livePublisher: LiveAtomPublisher = initialLivePublisher,
     previewPublisher: PreviewAtomPublisher = initialPreviewPublisher,
-    shutDownHook: AtomTestConf => Unit = _.app.stop) {
+    shutDownHook: AtomTestConf => Unit = _.app.stop()) {
 
     private def makeOverrides: GuiceableModule = Seq(
       ibind(dataStore),

--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomSuite.scala
@@ -5,7 +5,7 @@ import com.gu.atom.data._
 import com.gu.atom.publish.{LiveAtomPublisher, PreviewAtomPublisher}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar.mock
+import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.PlaySpec
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule, GuiceableModuleConversions}
 import play.api.inject.{Binding, bind}

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -13,9 +13,10 @@ dependencyOverrides += "com.twitter" %% "scrooge-core" % scroogeVersion
 dependencyOverrides += "com.twitter" %% "scrooge-serializer" % scroogeVersion
 
 libraryDependencies ++= Seq(
-  "org.typelevel"              %% "cats-core"             % "1.5.0",
-  "io.circe"                   %% "circe-parser"          % "0.11.0",
-  "com.gu"                     %% "fezziwig"              % "1.1",
+  "org.scala-lang.modules"     %% "scala-collection-compat" % "2.8.1",
+  "org.typelevel"              %% "cats-core"             % "2.9.0",
+  "io.circe"                   %% "circe-parser"          % "0.14.3",
+  "com.gu"                     %% "fezziwig"              % "1.6",
   "com.gu"                     %% "content-atom-model"    % contentAtomVersion,
   "com.amazonaws"              %  "aws-java-sdk-dynamodb" % awsVersion,
   "com.amazonaws"              %  "aws-java-sdk-kinesis"  % awsVersion,

--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -23,5 +23,6 @@ libraryDependencies ++= Seq(
   "com.twitter"                %% "scrooge-serializer"    % scroogeVersion,
   "com.twitter"                %% "scrooge-core"          % scroogeVersion,
   "org.mockito"                %  "mockito-core"          % mockitoVersion % Test,
-  "org.scalatest"              %% "scalatest"             % "3.0.0" % Test
+  "org.scalatestplus"          %% "mockito-4-6"           % "3.2.14.0" % Test,
+  "org.scalatest"              %% "scalatest"             % "3.2.14" % Test
 )

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/data/DynamoDataStore.scala
@@ -14,7 +14,7 @@ import io.circe.syntax._
 import com.gu.fezziwig.CirceScroogeMacros.{encodeThriftStruct, encodeThriftUnion}
 import com.gu.atom.util.JsonSupport.{backwardsCompatibleAtomDecoder, thriftEnumEncoder}
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 object AtomSerializer {

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -28,9 +28,9 @@ class DynamoDataStoreSpec
   type FixtureParam = DataStores
 
   def withFixture(test: OneArgTest) = {
-    val previewDb = new PreviewDynamoDataStore(LocalDynamoDB.client, tableName)
-    val compositeKeyDb = new PreviewDynamoDataStore(LocalDynamoDB.client, compositeKeyTableName)
-    val publishedDb = new PublishedDynamoDataStore(LocalDynamoDB.client, publishedTableName)
+    val previewDb = new PreviewDynamoDataStore(LocalDynamoDB.client(), tableName)
+    val compositeKeyDb = new PreviewDynamoDataStore(LocalDynamoDB.client(), compositeKeyTableName)
+    val publishedDb = new PublishedDynamoDataStore(LocalDynamoDB.client(), publishedTableName)
     super.withFixture(test.toNoArgTest(DataStores(previewDb, publishedDb, compositeKeyDb)))
   }
 
@@ -135,9 +135,9 @@ class DynamoDataStoreSpec
   }
 
   override def beforeAll() = {
-    val client = LocalDynamoDB.client
-    LocalDynamoDB.createTable(client)(tableName)('id -> S)
-    LocalDynamoDB.createTable(client)(publishedTableName)('id -> S)
-    LocalDynamoDB.createTable(client)(compositeKeyTableName)('atomType -> S, 'id -> S)
+    val client = LocalDynamoDB.client()
+    LocalDynamoDB.createTable(client)(tableName)(Symbol("id") -> S)
+    LocalDynamoDB.createTable(client)(publishedTableName)(Symbol("id") -> S)
+    LocalDynamoDB.createTable(client)(compositeKeyTableName)(Symbol("atomType") -> S, Symbol("id") -> S)
   }
 }

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/DynamoDataStoreSpec.scala
@@ -5,10 +5,12 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import com.gu.atom.TestData._
 import com.gu.atom.util.{AtomImplicitsGeneral, JsonSupport}
 import com.gu.contentatom.thrift.Atom
-import org.scalatest.{BeforeAndAfterAll, Matchers, OptionValues, fixture}
+import org.scalatest.{BeforeAndAfterAll, OptionValues}
+import org.scalatest.matchers.should._
+import org.scalatest.funspec.FixtureAnyFunSpec
 
 class DynamoDataStoreSpec
-    extends fixture.FunSpec
+    extends FixtureAnyFunSpec
     with Matchers
     with OptionValues
     with BeforeAndAfterAll

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/data/LocalDynamoDB.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/data/LocalDynamoDB.scala
@@ -2,8 +2,7 @@ package com.gu.atom.data
 
 import com.amazonaws.services.dynamodbv2._
 import com.amazonaws.services.dynamodbv2.model._
-
-import scala.collection.convert.decorateAsJava._
+import scala.jdk.CollectionConverters._
 
 /*
  * copied from:

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomPublisherSpec.scala
@@ -6,13 +6,14 @@ import com.gu.atom.TestData._
 import com.gu.atom.publish.KinesisAtomPublisher
 import org.mockito.ArgumentMatchers.{eq => argEq, _}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.{Failure, Success}
 
 class KinesisAtomPublisherSpec
-    extends FunSpec
+    extends AnyFunSpec
     with Matchers
     with MockitoSugar {
 

--- a/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
+++ b/atom-publisher-lib/src/test/scala/com/gu/atom/publish/test/KinesisAtomReindexerSpec.scala
@@ -6,14 +6,15 @@ import com.gu.atom.publish.{PreviewKinesisAtomReindexer, PublishedKinesisAtomRei
 import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class KinesisAtomReindexerSpec
-    extends FunSpecLike
+    extends AnyFunSpecLike
     with Matchers
     with ScalaFutures
     with MockitoSugar {

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ name := "atom-maker-lib"
 
 lazy val baseSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.12.16",
+  scalaVersion := "2.12.17",
+  crossScalaVersions := Seq(scalaVersion.value, "2.13.10"),
   licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/atom-maker"),
     "scm:git:git@github.com:guardian/atom-maker.git")),
@@ -38,6 +39,7 @@ lazy val atomLibraries = (project in file("."))
   publishArtifact := false,
   publish := {},
   publishLocal := {},
+  releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,
@@ -46,7 +48,8 @@ lazy val atomLibraries = (project in file("."))
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    releaseStepCommand("publishSigned"),
+    // For non cross-build projects, use releaseStepCommand("publishSigned")
+    releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
     setNextVersion,
     commitNextVersion,


### PR DESCRIPTION
Upgrading to Scala 2.13 as-soon-as-possible has been a DevX [recommendation](https://docs.google.com/document/d/1ovAD8OuWh5pQQecy4Yc4xmbRJwL3gbPiY2eJg3zU9Mg/edit) since January 2022, we're getting there!

The `atom-publisher-lib` library in this project is used by two other repos:

* https://github.com/guardian/atom-workshop
* https://github.com/guardian/media-atom-maker

...once `atom-maker` is available for Scala v2.13, it should become possible to upgrade `atom-workshop` & `media-atom-maker` to Scala 2.13 in the future too.

This PR has 2 commits:

* Upgrading ScalaTest to the latest version (which supports Scala v2.13 as well as v2.12)
* Small Scala syntax changes removing deprecation warnings - the changes are compatible with both Scala v2.13 as well as v2.12. The CI is also updated to run against both versions of Scala too.
