### PR TITLE
Bump play, aws-sdk and thrift minor versions

### DIFF
--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -8,7 +8,7 @@ startDynamoDBLocal := startDynamoDBLocal.dependsOn(Test / compile).value
 Test / test := (Test / test).dependsOn(startDynamoDBLocal).value
 Test / testOptions += dynamoDBLocalTestCleanup.value
 
-dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.10.0"
+dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.18.0"
 dependencyOverrides += "com.twitter" %% "scrooge-core" % scroogeVersion
 dependencyOverrides += "com.twitter" %% "scrooge-serializer" % scroogeVersion
 

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -1,9 +1,9 @@
 import sbt._
 
 object BuildVars {
-  lazy val awsVersion         = "1.11.8"
+  lazy val awsVersion         = "1.12.410"
   lazy val contentAtomVersion = "3.2.0"
   lazy val scroogeVersion     = "19.9.0"
-  lazy val playVersion        = "2.8.8"
+  lazy val playVersion        = "2.8.19"
   lazy val mockitoVersion     = "4.8.0"
 }


### PR DESCRIPTION
## What does this change?

In order to fix some vulnerabilities, this bumps the minor versions of:
- "org.apache.thrift" % "libthrift"
- "com.amazonaws" % "aws-java-sdk-dynamodb"
- "com.amazonaws" % "aws-java-sdk-kinesis"
- "com.typesafe.play" %% "play-test"
- "com.typesafe.play" %% "play"

## How to test

Run `sbt test`. Does everything pass?