### PR TITLE
Bump content-atom-model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ public/dist
 .DS_Store
 .java-version
 .bsp/
+.metals
+.vscode

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
-  lazy val contentAtomVersion = "3.2.0"
-  lazy val scroogeVersion     = "19.9.0"
+  lazy val contentAtomVersion = "3.4.1"
+  lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "2.8.8"
   lazy val mockitoVersion     = "4.8.0"
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This bumps the version of `content-atom-model` to `3.4.1`. Scrooge also needed to be bumped in order for the project to be compatible with the new version of `content-atom-model`. I also added some files to `.gitignore` to prevent them interfering with the release process.

This change is needed because `media-atom-maker` depends on `atom-maker` for access to `content-atom-model` - and support for Youtube-specific thumbnails in `media-atom-maker` depends on version `content-atom-model` `3.4.1`.

## How to test

Run `sbt compile` and `sbt test` from this repository to check that the project compiles and the tests pass.

I've also published locally (`sbt publishLocal`) and used that version in my local version of `media-atom-maker` to check that it's compatible.