### PR TITLE
Bump `content-atom-model` version to 3.4.4

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
-  lazy val contentAtomVersion = "3.4.1"
+  lazy val contentAtomVersion = "3.4.4"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "2.8.8"
   lazy val mockitoVersion     = "4.8.0"


### PR DESCRIPTION
## What does this change?

This bumps the `content-atom-model` version up to 3.4.4, giving access to [an updated recipe thrift model](https://github.com/guardian/content-atom/pull/156). This is part of an ongoing effort to get a barebones recipe atom pipeline working. 

## How to test

Run sbt compile and sbt test from this repository to check that the project compiles and the tests pass.
