### PR TITLE
Sonatype release through Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,7 @@
 name: 'Publish Release'
-
 on:
-  workflow_dispatch:
-    inputs:
-      isSnapshot:
-        description: Produce a snapshot release
-        required: true
-        default: true
-        type: boolean
-
+  release:
+    types: [published]
 jobs:
   sbt_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ jobs:
     steps:
       - uses: guardian/actions-sbt-release@v3
         with:
-            fetchDepth: 0
             pgpSecret: ${{ secrets.PGP_SECRET }}
             pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
             sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release Sonatype
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release_snapshot_sonatype:
+    if: "github.event.release.prerelease"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          base: main
+      - uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: sbt
+      - name: Release Snapshot (prerelease) to Sonatype
+        run: |
+          VERSION=$(git describe --tags | cut -f2 -d"@")
+          if [[ ${VERSION:0:1} == "v" ]] ; then
+            VERSION=${VERSION:1}
+          fi
+          if [[ ${VERSION: -9} != "-SNAPSHOT" ]] ; then
+            echo "Version must end in -SNAPSHOT. Adding -SNAPSHOT suffix"
+            VERSION="$VERSION-SNAPSHOT"
+          fi
+          echo $PGP_SECRET | base64 --decode | gpg --batch --import
+          export GPG_TTY=$(tty)
+          echo "Releasing version $VERSION Sonatype as snapshot"
+          yes | sbt -DRELEASE_TYPE=snapshot "clean" "release cross release-version $VERSION with-defaults"
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,23 @@
-name: Release Sonatype
+name: 'Publish Release'
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      isSnapshot:
+        description: Produce a snapshot release
+        required: true
+        default: true
+        type: boolean
 
 jobs:
-  release_snapshot_sonatype:
-    if: "github.event.release.prerelease"
+  sbt_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: guardian/actions-sbt-release@v3
         with:
-          base: main
-      - uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 11
-          cache: sbt
-      - name: Release Snapshot (prerelease) to Sonatype
-        run: |
-          VERSION=$(git describe --tags | cut -f2 -d"@")
-          if [[ ${VERSION:0:1} == "v" ]] ; then
-            VERSION=${VERSION:1}
-          fi
-          if [[ ${VERSION: -9} != "-SNAPSHOT" ]] ; then
-            echo "Version must end in -SNAPSHOT. Adding -SNAPSHOT suffix"
-            VERSION="$VERSION-SNAPSHOT"
-          fi
-          echo $PGP_SECRET | base64 --decode | gpg --batch --import
-          export GPG_TTY=$(tty)
-          echo "Releasing version $VERSION Sonatype as snapshot"
-          yes | sbt -DRELEASE_TYPE=snapshot "clean" "release cross release-version $VERSION with-defaults"
-        env:
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+            fetchDepth: 0
+            pgpSecret: ${{ secrets.PGP_SECRET }}
+            pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
+            sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+            sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+            isSnapshot: ${{ github.event.release.prerelease }}

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,22 @@ lazy val atomManagerPlay = (project in file("./atom-manager-play-lib"))
   .settings(Test / publishArtifact := true)
   .dependsOn(atomPublisher % "test->test;compile->compile")
 
+lazy val commonReleaseProcess = Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  setReleaseVersion,
+  runClean,
+  runTest,
+  // For non cross-build projects, use releaseStepCommand("publishSigned")
+  releaseStepCommandAndRemaining("+publishSigned"),
+)
+
+lazy val productionReleaseProcess = commonReleaseProcess ++ Seq[ReleaseStep](
+  releaseStepCommand("sonatypeBundleRelease"),
+)
+
+lazy val snapshotReleaseProcess = commonReleaseProcess
+
 lazy val atomLibraries = (project in file("."))
   .aggregate(atomPublisher, atomManagerPlay)
   .settings(baseSettings: _*).settings(
@@ -40,19 +56,12 @@ lazy val atomLibraries = (project in file("."))
   publish := {},
   publishLocal := {},
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    // For non cross-build projects, use releaseStepCommand("publishSigned")
-    releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
-    setNextVersion,
-    commitNextVersion,
-    pushChanges
-  )
+  releaseProcess := {
+    sys.props.get("RELEASE_TYPE") match {
+      case Some("production") => productionReleaseProcess
+      case _ => snapshotReleaseProcess
+    }
+  }
 )
+
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")

--- a/build.sbt
+++ b/build.sbt
@@ -63,5 +63,3 @@ lazy val atomLibraries = (project in file("."))
     }
   }
 )
-
-resolvers ++= Resolver.sonatypeOssRepos("snapshots")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "1.3.5-SNAPSHOT"


### PR DESCRIPTION
# What does this change?
This updates the release process so that this library is published to Sonatype via Github actions.

- It introduces release.yml
- Removes version.sbt
- Tweaks build.sbt to enable the release process

The release process is built on the guardian/actions-sbt-release action, which does some version housekeeping and then runs sbt release.

## How to test
Tested on snapshot release through the GH releases UI. See the build logs in the Actions tab.

## How can we measure success?
We should be able to create a release in github, either snapshot or production, and it will be appropriate signed and pushed to Maven.

## Have we considered potential risks?
This is low risk change.