### PR TITLE
Bump content atom version to v4.0.0

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.11.8"
-  lazy val contentAtomVersion = "3.4.1"
+  lazy val contentAtomVersion = "4.0.0"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "2.8.8"
   lazy val mockitoVersion     = "4.8.0"


### PR DESCRIPTION
Bump content atom library to 4.0.0 to deprecate recipe atom