### PR TITLE
Fix tests under Java 17 (Guice & Play upgrade)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11']
+        java: [ '11', '17']
     name: Run Tests (Java ${{ matrix.java }})
     steps:
     - name: Checkout

--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -5,7 +5,7 @@ name := "atom-manager-play"
 libraryDependencies ++= Seq(
   "com.typesafe.play"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
-  "org.scalatestplus.play" %% "scalatestplus-play"    % "5.1.0" % Test,
+  "org.scalatestplus.play" %% "scalatestplus-play"    % "6.0.1" % Test,
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
   "org.mockito"            %  "mockito-core"          % mockitoVersion % Test,
   "com.typesafe.play"      %% "play-test"             % playVersion % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -6,10 +6,9 @@ name := "atom-maker-lib"
 
 lazy val artifactProductionSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.12.18",
-  crossScalaVersions := Seq(scalaVersion.value, "2.13.12"),
+  scalaVersion := "2.13.12",
   licenses := Seq(License.Apache2),
-  scalacOptions := Seq("-deprecation", "-feature", "-release:8")
+  scalacOptions := Seq("-deprecation", "-feature", "-release:11")
 )
 
 lazy val atomPublisher = (project in file("./atom-publisher-lib"))
@@ -32,7 +31,6 @@ lazy val atomLibraries = (project in file("."))
   .aggregate(atomPublisher, atomManagerPlay).settings(
     publish / skip := true,
     releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
-    releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -4,6 +4,6 @@ object BuildVars {
   lazy val awsVersion         = "1.11.8"
   lazy val contentAtomVersion = "4.0.0"
   lazy val scroogeVersion     = "22.1.0"
-  lazy val playVersion        = "2.8.8"
-  lazy val mockitoVersion     = "4.8.0"
+  lazy val playVersion        = "2.9.1"
+  lazy val mockitoVersion     = "4.11.0"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")


### PR DESCRIPTION
# What's changing?

* Adopt Play 2.9
* Drop Scala 2.12, support only Scala 2.13
* Drop Java 8, make Java 11 the minimum required version of Java

# Why?

After PR https://github.com/guardian/atom-maker/pull/93, installing [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow), we found that unfortunately the [release workflow failed](https://github.com/guardian/atom-maker/actions/runs/7556731459) with an `InaccessibleObjectException` while running the tests (which in this project's [normal CI](https://github.com/guardian/atom-maker/blob/500676487a9ac07e5332bf575b51114d0108880e/.github/workflows/ci.yml#L13) used only Java 8 & 11 up till now):

* The Release workflow uses Java 17 for all builds
* The Atom Maker library uses Play with Guice for Dependency Injection
* Guice only gained Java 17 & 21 support with [Guice v6](https://github.com/google/guice/wiki/Guice600)
* Play only updated to Guice v6 (and gained general Java 17 support) with **Play v2.9** - which does not support **Scala 2.12**, or **Java 8**: https://github.com/playframework/playframework/pull/11808 [Play requirements update](https://github.com/playframework/playframework/commit/10ca54da9bef08551101b39b7e871cbfe894ac7b#diff-3dc52110c1c1c453c2e9740ac58fe7e90d53121875a034ef3109c34ab030c29e)

# How to test?

The new [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) added in #93 made it easy to publish a [pre-release version](https://index.scala-lang.org/guardian/atom-maker/artifacts/atom-publisher-lib/2.0.0-PREVIEW.fix-tests-under-java-17.2024-01-18T1039.b4d55b3d) of this PR (see https://github.com/guardian/atom-maker/pull/94#issuecomment-1898231834 - even though release of main branch currently isn't working due to this issue, the preview release of _this_ branch fixing the problem _does_ work!): 

```sbt
libraryDependencies += "com.gu" %% "atom-publisher-lib" % "2.0.0-PREVIEW.fix-tests-under-java-17.2024-01-18T1039.b4d55b3d"
```

This has been slotted into https://github.com/guardian/atom-workshop/pull/349, alongside an upgrade to Play 2.9 & Scala 2.13 there, to check that this all works.

Note that the automated version-compatibility testing has also correctly decided that this change requires a 'major' version bump, from 1.4.0 to 2.0.0!

# Consumers affected by this update

Code search for [`atom-publisher-lib`](https://github.com/search?q=org%3Aguardian+%22atom-publisher-lib%22+NOT+repo%3Aguardian%2Fatom-maker&type=code) & [`atom-manager-play`](https://github.com/search?q=org%3Aguardian+%22atom-manager-play%22+NOT+repo%3Aguardian%2Fatom-maker&type=code) confirms that at the Guardian we have only 4 applications using the libraries published by this repo, of which 2 are archived:

* https://github.com/guardian/atom-workshop - https://github.com/guardian/atom-workshop/pull/349
* https://github.com/guardian/media-atom-maker - https://github.com/guardian/media-atom-maker/pull/1140
* https://github.com/guardian/explain-maker - ARCHIVED
* https://github.com/guardian/review-maker - ARCHIVED