### PR TITLE
Upgrade to Play 3.0

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -3,11 +3,11 @@ import BuildVars._
 name := "atom-manager-play"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play"      %% "play"                  % playVersion,
+  "org.playframework"      %% "play"                  % playVersion,
   "com.gu"                 %% "content-atom-model"    % contentAtomVersion,
-  "org.scalatestplus.play" %% "scalatestplus-play"    % "6.0.1" % Test,
+  "org.scalatestplus.play" %% "scalatestplus-play"    % "7.0.1" % Test,
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
   "org.mockito"            %  "mockito-core"          % mockitoVersion % Test,
-  "com.typesafe.play"      %% "play-test"             % playVersion % Test,
+  "org.playframework"      %% "play-test"             % playVersion % Test,
   guice
 )

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
@@ -2,9 +2,9 @@ package com.gu.atom.play
 
 import java.util.Date
 import javax.inject.{Inject, Singleton}
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import akka.pattern.ask
-import akka.util.Timeout
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 import com.gu.atom.data._
 import com.gu.atom.play.ReindexActor._
 import com.gu.atom.publish._

--- a/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
+++ b/atom-manager-play-lib/src/main/scala/com.gu.atom/play/reindex.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
  */
 
 class ReindexActor(reindexer: AtomReindexer) extends Actor {
-  implicit val ec = context.dispatcher
+  implicit val ec: ExecutionContext = context.dispatcher
 
   /* this is the initial, idle state. In this state we will accept new jobs */
   def idleState(lastJob: Option[AtomReindexJob]): Receive = {
@@ -96,14 +96,14 @@ class ReindexController @Inject() (
 
   def now() = new Date().getTime
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   val previewReindexActor = system.actorOf(Props(classOf[ReindexActor], previewReindexer))
   val publishedReindexActor = system.actorOf(Props(classOf[ReindexActor], publishedReindexer))
 
-  implicit val timeout = Timeout(5.seconds)
+  implicit val timeout: Timeout = Timeout(5.seconds)
 
-  implicit val statusWrites = Json.writes[JobStatus]
+  implicit val statusWrites: Writes[JobStatus] = Json.writes[JobStatus]
 
   object ApiKeyAction extends ActionBuilder[Request, AnyContent] {
     lazy val apiKey = config.get[String]("reindexApiKey")

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -4,6 +4,6 @@ object BuildVars {
   lazy val awsVersion         = "1.11.1034"
   lazy val contentAtomVersion = "4.0.0"
   lazy val scroogeVersion     = "22.1.0"
-  lazy val playVersion        = "2.9.1"
+  lazy val playVersion        = "3.0.2"
   lazy val mockitoVersion     = "4.11.0"
 }


### PR DESCRIPTION
## What does this change?

Minimal changes to upgrade to Play 3.0. This includes switching from Akka to Pekko. 

## How can we measure success?

I can upgrade atom-workshop to Play 3.0