### PR TITLE
Bump various libraries

### DIFF
--- a/atom-publisher-lib/build.sbt
+++ b/atom-publisher-lib/build.sbt
@@ -14,9 +14,9 @@ dependencyOverrides += "com.twitter" %% "scrooge-serializer" % scroogeVersion
 
 libraryDependencies ++= Seq(
   "org.scala-lang.modules"     %% "scala-collection-compat" % "2.8.1",
-  "org.typelevel"              %% "cats-core"             % "2.9.0",
+  "org.typelevel"              %% "cats-core"             % "2.10.0",
   "io.circe"                   %% "circe-parser"          % "0.14.3",
-  "com.gu"                     %% "fezziwig"              % "1.6",
+  "com.gu"                     %% "fezziwig"              % "1.9.2",
   "com.gu"                     %% "content-atom-model"    % contentAtomVersion,
   "com.amazonaws"              %  "aws-java-sdk-dynamodb" % awsVersion,
   "com.amazonaws"              %  "aws-java-sdk-kinesis"  % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "atom-maker-lib"
 
 lazy val artifactProductionSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.13.12",
+  scalaVersion := "2.13.13",
   licenses := Seq(License.Apache2),
   scalacOptions := Seq("-deprecation", "-feature", "-release:11")
 )

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object BuildVars {
-  lazy val awsVersion         = "1.11.1034"
-  lazy val contentAtomVersion = "4.0.0"
+  lazy val awsVersion         = "1.12.679"
+  lazy val contentAtomVersion = "4.0.1"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "3.0.2"
   lazy val mockitoVersion     = "4.11.0"


### PR DESCRIPTION
## What does this change?

Updates: 
- Scala version (patch)
- AWS SDK (minor)
- Content Atom (patch)
- Cats (minor)
- Fezziwig (minor)

Reduces Snyk vulnerabilites