### PR TITLE
Remove references to old release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,9 @@ In your routes file:
 ```
 POST    /api/atom/:id/publish           controllers.MyAtomController.publishAtom(id)
 ```
+
+# Publishing a new release
+
+This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+to automate publishing releases (both full & preview releases) - see
+[**Making a Release**](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).

--- a/README.md
+++ b/README.md
@@ -173,6 +173,3 @@ In your routes file:
 ```
 POST    /api/atom/:id/publish           controllers.MyAtomController.publishAtom(id)
 ```
-
-## Releasing a new version
-Run `./script/release` from the project root.

--- a/script/release
+++ b/script/release
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-echo 'Releasing a new version of atom-maker, it will take a while - go get a coffee!'
-
-sbt release
-
-echo '✅ Done'


### PR DESCRIPTION
## What does this change?

Follow up to https://github.com/guardian/atom-maker/pull/93