### PR TITLE
remove play-guice from atom-manager-play-lib

### DIFF
--- a/atom-manager-play-lib/build.sbt
+++ b/atom-manager-play-lib/build.sbt
@@ -8,6 +8,5 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play"    % "7.0.1" % Test,
   "com.amazonaws"          %  "aws-java-sdk-dynamodb" % awsVersion,
   "org.mockito"            %  "mockito-core"          % mockitoVersion % Test,
-  "org.playframework"      %% "play-test"             % playVersion % Test,
-  guice
+  "org.playframework"      %% "play-test"             % playVersion % Test
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
-
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")


### PR DESCRIPTION
## What does this change?

We're only using it for convenience in tests, and it doesn't form part of the API so no need to be installed in dependents (unless they're using it, in which case it should be part of _their_ dependency list), and play-test already brings in play-guice in the test scope so no need to even explicitly depend on it. This removes the last symbol from the play plugin, so we can remove that too, which means the Play version is only defined in one place so cannot go out of sync again.

## How to test

Compiles, tests pass, last remnants of Play v2.x removed from dependency tree.