### PR TITLE
Bump contentAtomVersion to version 10.0.0

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.12.680"
-  lazy val contentAtomVersion = "9.0.0"
+  lazy val contentAtomVersion = "10.0.0"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "3.0.10"
   lazy val mockitoVersion     = "4.11.0"


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/content-atom/pull/208 updates the thrift atom model used by Media Atom Maker and downstream web and app clients.

This PR updates to the latest version content-atom-model library so it can be used in Media Atom Maker.

## Relevant PRs

- [content-atom](https://github.com/guardian/content-atom/pull/208)
- [atom-maker](https://github.com/guardian/atom-maker/pull/141) <- you are here
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3335)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3336)
- [content-api-models](https://github.com/guardian/content-api-models/pull/297)
- [content-api (Concierge)](https://github.com/guardian/content-api/pull/3337)
