### PR TITLE
Bump content atom thrift model to v11

### DIFF
--- a/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
+++ b/atom-manager-play-lib/src/test/scala/com.gu/play/AtomAPIActionsSpec.scala
@@ -43,7 +43,7 @@ class AtomAPIActionsSpec extends AtomSuite with Inside {
       verify(conf.publishedDataStore).updateAtom(atomCaptor.capture())
       
       inside(atomCaptor.getValue) {
-        case Atom("1", _, _, _, _, changeDetails, _, _, _) => {
+        case Atom("1", _, _, _, _, changeDetails, _, _, _, _) => {
           changeDetails.published.value.date must be >= startTime
           changeDetails.revision mustEqual 2
         }

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.12.680"
-  lazy val contentAtomVersion = "10.0.0"
+  lazy val contentAtomVersion = "11.0.0-PREVIEW.wsadd-tag-to-atom.2026-04-30T1425.deb1ffbf"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "3.0.10"
   lazy val mockitoVersion     = "4.11.0"

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.12.680"
-  lazy val contentAtomVersion = "11.0.0-PREVIEW.wsadd-tag-to-atom.2026-04-30T1425.deb1ffbf"
+  lazy val contentAtomVersion = "11.0.0"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "3.0.10"
   lazy val mockitoVersion     = "4.11.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We made a change to the content atom thrift model in guardian/content-atom#211.  This pull request updates the atom maker libraries to use that content atom model (v11) so that the Media Atom Maker can save atoms with the updated model and publish them to Kinesis stream via these libraries.
