### PR TITLE
Bump to content-atom v12.0.1

### DIFF
--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.12.680"
-  lazy val contentAtomVersion = "11.0.0"
+  lazy val contentAtomVersion = "12.0.1"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "3.0.10"
   lazy val mockitoVersion     = "4.11.0"


### PR DESCRIPTION
This adds a new optional parameter codecs for media atoms. See https://github.com/guardian/content-atom/pull/216