### PR TITLE
Upgrade content-atom-model version

### DIFF
--- a/atom-publisher-lib/src/main/scala/com/gu/atom/util/JsonSupport.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/util/JsonSupport.scala
@@ -67,7 +67,7 @@ object JsonSupport {
           val nestedDataFieldName = atomType.toLowerCase
 
           //Special case for commonsDivision because the scrooge enum value loses the casing
-          if (data(nestedDataFieldName).nonEmpty || nestedDataFieldName == "commonsdivision" || nestedDataFieldName == "footballcompetition") c.value
+          if (data(nestedDataFieldName).nonEmpty || nestedDataFieldName == "commonsdivision" || nestedDataFieldName == "tempfootballcompetition") c.value
           else {
             //Add the union type name under `data`
             val newData = JsonObject.fromIterable(Seq(nestedDataFieldName -> dataJson))

--- a/atom-publisher-lib/src/main/scala/com/gu/atom/util/JsonSupport.scala
+++ b/atom-publisher-lib/src/main/scala/com/gu/atom/util/JsonSupport.scala
@@ -67,7 +67,7 @@ object JsonSupport {
           val nestedDataFieldName = atomType.toLowerCase
 
           //Special case for commonsDivision because the scrooge enum value loses the casing
-          if (data(nestedDataFieldName).nonEmpty || nestedDataFieldName == "commonsdivision") c.value
+          if (data(nestedDataFieldName).nonEmpty || nestedDataFieldName == "commonsdivision" || nestedDataFieldName == "footballcompetition") c.value
           else {
             //Add the union type name under `data`
             val newData = JsonObject.fromIterable(Seq(nestedDataFieldName -> dataJson))

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.12.680"
-  lazy val contentAtomVersion = "12.1.0-PREVIEW.add-new-atom-for-match-day.2026-06-29T0857.762a6566"
+  lazy val contentAtomVersion = "12.1.0-PREVIEW.add-new-atom-for-match-day.2026-07-15T1141.302c1611"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "3.0.10"
   lazy val mockitoVersion     = "4.11.0"

--- a/project/BuildVars.scala
+++ b/project/BuildVars.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object BuildVars {
   lazy val awsVersion         = "1.12.680"
-  lazy val contentAtomVersion = "12.0.1"
+  lazy val contentAtomVersion = "12.1.0-PREVIEW.add-new-atom-for-match-day.2026-06-29T0857.762a6566"
   lazy val scroogeVersion     = "22.1.0"
   lazy val playVersion        = "3.0.10"
   lazy val mockitoVersion     = "4.11.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
